### PR TITLE
docs: add stdio transport support to MCP gateway docs

### DIFF
--- a/docs/enterprise_mcp_gateway_architecture_diagram.md
+++ b/docs/enterprise_mcp_gateway_architecture_diagram.md
@@ -1,0 +1,114 @@
+## Architecture Overview
+
+The Enterprise MCP Gateway is a centrally deployed control plane and data plane component that sits between enterprise AI tools and MCP servers.
+
+---
+
+## High-Level Architecture (Logical)
+
+```mermaid
+graph LR
+    User[User]
+    AI[Enterprise AI Tool]
+    IdP[Okta / OAuth2]
+    GW[Enterprise MCP Gateway]
+    Policy[Policy Config
+(YAML/JSON)]
+    Presidio[Presidio
+Masking Engine]
+    MCP1[Remote MCP Server
+HTTP]
+    MCP2[External MCP Server
+HTTP]
+    MCP3[Gateway-Managed
+MCP Server
+stdio]
+    Logs[Enterprise Logging / SIEM]
+
+    User --> AI
+    AI -->|OAuth2 Auth| IdP
+    AI -->|MCP over HTTP| GW
+
+    GW --> Policy
+    GW --> Presidio
+
+    GW -->|"Streamable HTTP
+(Act as User)"| MCP1
+    GW -->|"Streamable HTTP
+(Act as User)"| MCP2
+    GW -->|"stdio
+(Spawned Process)"| MCP3
+
+    GW --> Logs
+```
+
+---
+
+## Component Responsibilities
+
+### Enterprise AI Tool
+- Performs user-interactive OAuth2 login
+- Sends all MCP requests through the gateway
+- Does not embed governance or masking logic
+
+### MCP Gateway (Data Plane)
+- Terminates MCP requests (Streamable HTTP and stdio)
+- Validates OAuth2 tokens
+- Resolves user identity and groups
+- Evaluates governance policies
+- Applies inline Presidio masking
+- Proxies requests to MCP servers
+- Emits structured audit logs
+
+### Policy Configuration (Control Plane)
+- Static YAML/JSON files
+- Loaded at startup
+- Defines allow/deny rules by user, group, server, tool
+
+### Presidio Integration
+- Inline detection and masking
+- Pluggable interface
+- No persistence of unmasked data
+
+### MCP Servers
+- First-party or third-party
+- No awareness of governance logic
+- Receive already-masked inputs
+- **Remote servers** communicate via Streamable HTTP
+- **Gateway-managed servers** communicate via stdio (spawned as child processes by the gateway)
+
+### Logging & SIEM
+- Receives stdout logs via platform logging
+- Provides retention, search, alerting
+
+---
+
+## Transport Model
+
+The gateway supports two MCP transport modes:
+
+### Streamable HTTP (Remote Servers)
+- Gateway connects to remote MCP servers over HTTP
+- OBO token exchange provides user-scoped authorization at the downstream server
+- Primary model for third-party and externally hosted MCP servers
+
+### stdio (Gateway-Managed Servers)
+- Gateway spawns MCP server processes locally and communicates via stdin/stdout
+- Server runs as a subprocess of the gateway — no network boundary between gateway and server
+- User identity is propagated via the gateway's process context
+- Governance, masking, and auditing apply identically to HTTP-connected servers
+
+---
+
+## Trust Boundaries
+- OAuth2 token trust boundary at gateway ingress
+- Enterprise boundary enforced before external MCP servers
+- Sensitive data never leaves boundary unmasked
+
+---
+
+## Explicit Non-Architecture
+- No endpoint agent
+- No local machine enforcement
+- No policy authoring UI
+

--- a/docs/enterprise_mcp_gateway_implementation_plan_epics.md
+++ b/docs/enterprise_mcp_gateway_implementation_plan_epics.md
@@ -1,0 +1,56 @@
+## Implementation Plan
+
+### Phase 0 – Foundations
+- Select language/runtime (Python)
+- Define MCP gateway service contract (covering both HTTP and stdio transports)
+- Define policy schema (YAML/JSON)
+- Define audit event schema
+
+---
+
+### Phase 1 – Core Gateway (MVP)
+
+#### Epic 1: Gateway Core
+- Story: Implement streamable HTTP MCP proxy
+- Story: Implement stdio transport for gateway-managed MCP servers
+- Story: Transport abstraction layer (HTTP and stdio behind common interface)
+- Story: Request/response lifecycle hooks
+- Story: Correlation ID propagation
+
+#### Epic 2: Identity & Auth
+- Story: Okta OAuth2 integration
+- Story: Token validation & user identity resolution
+- Story: Acting-as-user token forwarding model
+
+#### Epic 3: Governance Engine
+- Story: Policy file loader & validator
+- Story: Policy evaluation engine (server/tool/user)
+- Story: Allow/deny enforcement
+
+#### Epic 4: Presidio Integration
+- Story: Presidio plugin interface
+- Story: Inline input masking
+- Story: Inline output masking
+- Story: Masked logging guarantees
+
+#### Epic 5: Auditing & Logging
+- Story: Structured audit event emitter
+- Story: Stdout logging compatibility (EKS)
+- Story: Correlation & trace IDs
+
+---
+
+### Phase 2 – Hardening
+- Performance tuning
+- Failure modes & fallbacks
+- Documentation & runbooks
+
+---
+
+### Non-Goals (Explicit)
+- UI or admin console
+- Policy approval workflows
+- Dynamic policy updates
+- Tool risk classification
+- Local developer enforcement
+

--- a/docs/enterprise_mcp_gateway_leadership_explainer.md
+++ b/docs/enterprise_mcp_gateway_leadership_explainer.md
@@ -1,0 +1,34 @@
+## What This Is
+The Enterprise MCP Gateway is a control point that allows MCP to be used safely in regulated enterprise environments. It supports both HTTP and stdio MCP transports, covering remote MCP servers as well as gateway-managed server processes.
+
+It enables AI tools to use MCP while ensuring:
+- Only approved tools are accessible
+- Actions are attributable to real users
+- Sensitive data is masked
+- All activity is auditable
+
+---
+
+## What This Is Not
+- It is not a device control or endpoint lockdown tool
+- It does not prevent all local developer MCP usage
+- It is not a full DLP or intent-classification system
+
+---
+
+## Why This Matters
+Without a gateway, MCP adoption is blocked by security and compliance concerns. This system provides the minimum viable control surface required to approve MCP usage without halting innovation.
+
+---
+
+## Enforcement Reality
+- Hosted enterprise AI tools (HTTP or stdio through gateway): **enforced**
+- Local developer tools (direct stdio outside gateway): **monitored**
+
+This applies regardless of transport — when traffic flows through the gateway (HTTP or stdio), governance is enforced. Local developer MCP usage outside the gateway remains observability-only, reflecting technical reality and avoiding false security claims.
+
+---
+
+## Bottom Line
+The gateway makes MCP *approvable* in enterprise environments.
+

--- a/docs/enterprise_mcp_gateway_policy_schema_example.md
+++ b/docs/enterprise_mcp_gateway_policy_schema_example.md
@@ -1,0 +1,132 @@
+## Policy Schema Example (YAML)
+
+This example shows a **static, Git-managed policy file** suitable for MVP. It is intentionally explicit and default-deny.
+
+```yaml
+version: 1
+
+default: deny
+
+identity:
+  provider: okta
+  claim_mapping:
+    user_id: sub
+    email: email
+    groups: groups
+
+# Server connection registry — declares how the gateway reaches each MCP server
+servers:
+  - name: internal-infra-mcp
+    transport: http
+    url: https://infra-mcp.internal.corp/mcp
+  - name: github-mcp
+    transport: http
+    url: https://github-mcp.internal.corp/mcp
+  - name: audit-mcp
+    transport: stdio
+    command: /usr/local/bin/audit-mcp-server
+    args: ["--config", "/etc/audit-mcp/config.yaml"]
+  - name: local-tools-mcp
+    transport: stdio
+    command: /usr/local/bin/local-tools-server
+
+policies:
+  - id: allow-platform-ops-internal-tools
+    description: Allow Platform Ops to use approved internal MCP tools
+    effect: allow
+    subjects:
+      groups:
+        - platform-ops
+        - sre
+    mcp_servers:
+      - name: internal-infra-mcp
+        tools:
+          - read_logs
+          - query_metrics
+          - restart_service
+
+  - id: allow-dev-readonly-external
+    description: Allow developers to use read-only external MCP tools
+    effect: allow
+    subjects:
+      groups:
+        - developers
+    mcp_servers:
+      - name: github-mcp
+        tools:
+          - list_repos
+          - read_issues
+          - read_pull_requests
+
+  - id: deny-destructive-external
+    description: Explicitly deny destructive tools on external MCP servers
+    effect: deny
+    subjects:
+      groups:
+        - '*'
+    mcp_servers:
+      - name: '*'
+        tools:
+          - delete_*
+          - write_*
+
+  - id: allow-security-audit
+    description: Allow Security team to run audit tools
+    effect: allow
+    subjects:
+      groups:
+        - security
+        - compliance
+    mcp_servers:
+      - name: audit-mcp
+        tools:
+          - generate_audit_report
+          - list_access_events
+
+  - id: allow-dev-local-tools
+    description: Allow developers to use gateway-managed local tools
+    effect: allow
+    subjects:
+      groups:
+        - developers
+    mcp_servers:
+      - name: local-tools-mcp
+        tools:
+          - format_code
+          - lint_project
+
+logging:
+  level: info
+  include:
+    - user
+    - groups
+    - mcp_server
+    - tool
+    - decision
+    - correlation_id
+    - transport
+
+masking:
+  presidio:
+    enabled: true
+    entities:
+      - PERSON
+      - EMAIL_ADDRESS
+      - PHONE_NUMBER
+      - CREDIT_CARD
+      - API_KEY
+      - PASSWORD
+```
+
+---
+
+## Design Notes
+- Policies are evaluated top-down
+- Explicit deny overrides allow
+- Wildcards allowed for tools and servers
+- No dynamic reload in MVP (restart required)
+- Group membership is resolved from Okta token claims
+- **Transport type** is declared in the `servers` section for connection configuration; it is informational for policy purposes — governance applies equally regardless of whether the server uses HTTP or stdio
+- For `http` servers: `url` specifies the server endpoint
+- For `stdio` servers: `command` and optional `args` specify the process to spawn
+

--- a/docs/enterprise_mcp_gateway_security_compliance_positioning.md
+++ b/docs/enterprise_mcp_gateway_security_compliance_positioning.md
@@ -1,0 +1,57 @@
+## Security & Compliance Overview
+
+### Purpose
+This document defines the security and compliance posture of the Enterprise MCP Gateway without over-claiming controls beyond technical feasibility.
+
+---
+
+### Security Controls
+
+#### Identity & Access
+- OAuth2-based user authentication
+- Okta as system of record
+- User-scoped authorization enforced at gateway
+
+#### Governance
+- Explicit allow/deny policies
+- Server- and tool-level controls
+- Default-deny posture
+- Governance applies across both HTTP and stdio transports
+
+#### Data Protection
+- Inline PII and secret masking using Microsoft Presidio
+- No persistence of unmasked sensitive data
+
+#### Auditing
+- Comprehensive, structured audit logs
+- User attribution on every action
+- Policy decision capture
+
+---
+
+### Enforcement Model
+- **Gateway-proxied HTTP**: hard enforcement — full governance, OBO, masking, auditing
+- **Gateway-managed stdio**: hard enforcement — governance, masking, and auditing apply identically to spawned MCP server processes
+- **Local developer stdio** (outside gateway): observability-only — monitored through complementary controls
+- No endpoint or device control claims
+
+---
+
+### Compliance Alignment (Indicative)
+- SOC2: Access control, logging, change traceability
+- SOX: Auditability of system actions
+- HIPAA (supporting): Data minimization via masking
+
+---
+
+### Explicit Non-Claims
+- Does not prevent all local MCP usage
+- Does not enforce governance on stdio transport outside the gateway (e.g., local developer MCP clients connecting directly to stdio servers)
+- Does not provide DLP guarantees beyond masking
+- Does not classify tool risk or intent
+
+---
+
+### Risk Acceptance
+Residual risk exists for developer-local MCP usage; mitigated through monitoring and policy.
+

--- a/docs/enterprise_mcp_gateway_threat_model_canvas.md
+++ b/docs/enterprise_mcp_gateway_threat_model_canvas.md
@@ -1,0 +1,137 @@
+## Threat Model Canvas
+
+This canvas documents **what the MCP Gateway mitigates** and **what risks are explicitly accepted**. It is designed for Security and Architecture Review Boards.
+
+---
+
+## Assets
+- User identity and credentials
+- Enterprise data accessed via MCP tools
+- Audit logs and compliance evidence
+- Governance policy definitions
+
+---
+
+## Threats Mitigated
+
+### 1. Unauthorized Tool Access
+**Threat:** Users or agents invoke MCP tools they should not have access to.
+
+**Mitigation:**
+- Default-deny governance policies
+- Server- and tool-level allow lists
+- User/group-based authorization
+
+---
+
+### 2. Loss of Attribution
+**Threat:** MCP actions cannot be traced to a specific user.
+
+**Mitigation:**
+- OAuth2 user-interactive authentication
+- Acting-as-user execution model
+- User identity embedded in every audit event
+
+---
+
+### 3. Sensitive Data Exfiltration
+**Threat:** PII or secrets are sent to external MCP servers.
+
+**Mitigation:**
+- Inline Presidio masking before tool invocation
+- Inline masking on tool responses
+- No persistence of unmasked data
+
+---
+
+### 4. Compliance Audit Gaps
+**Threat:** Inability to demonstrate control over MCP usage.
+
+**Mitigation:**
+- Structured, comprehensive audit logging
+- Policy decision capture (allow/deny)
+- Correlation IDs for traceability
+
+---
+
+### 5. Shadow MCP Usage in Hosted AI
+**Threat:** Hosted AI tools bypass governance controls.
+
+**Mitigation:**
+- Mandatory gateway enforcement for hosted enterprise AI tools
+
+---
+
+### 6. stdio Server Governance
+**Threat:** Gateway-managed MCP servers spawned via stdio operate without governance or auditing.
+
+**Mitigation:**
+- When MCP servers are spawned by the gateway via stdio, governance policies, data masking, and audit logging apply identically to HTTP-connected servers
+- The gateway wraps all stdio communication with the same policy evaluation, Presidio masking, and audit emission pipeline
+- The enforcement boundary is the gateway, not the transport — stdio servers managed by the gateway receive the same controls as HTTP servers
+
+---
+
+## Threats Explicitly Accepted
+
+### 1. Local Developer MCP Usage
+**Risk:** Developers run MCP clients locally without gateway enforcement, including local stdio-based MCP servers not routed through the gateway.
+
+**Rationale:**
+- MCP protocol does not mandate centralized enforcement
+- Endpoint control is out of scope for this product
+- Local stdio connections between developer tools and MCP servers bypass the gateway entirely
+
+**Compensating Controls:**
+- Monitoring (e.g., CrowdStrike)
+- Policy and developer education
+
+---
+
+### 2. Malicious Tool Logic
+**Risk:** Approved MCP tools behave maliciously or unexpectedly.
+
+**Rationale:**
+- Gateway does not inspect tool intent or logic
+
+**Compensating Controls:**
+- Tool approval processes (outside MVP)
+- Server ownership and reviews
+
+---
+
+### 3. Over-Masking or Under-Masking
+**Risk:** Presidio misses sensitive data or masks too aggressively.
+
+**Rationale:**
+- NLP-based detection is probabilistic
+
+**Compensating Controls:**
+- Conservative masking policies
+- Periodic review of detection rules
+
+---
+
+### 4. Denial of Service via Gateway
+**Risk:** Gateway outage blocks MCP usage.
+
+**Rationale:**
+- Centralized enforcement introduces a control-plane dependency
+
+**Compensating Controls:**
+- High availability deployment
+- Clear failure modes and alerts
+
+---
+
+## Non-Threats (Out of Scope)
+- Endpoint compromise
+- Insider threats outside MCP usage
+- Full DLP or intent classification
+- stdio as a transport is not inherently less secure — the enforcement boundary is the gateway, not the wire protocol
+
+---
+
+## Summary
+The MCP Gateway significantly reduces enterprise risk for MCP adoption while explicitly acknowledging and documenting residual risks that require complementary controls.
+

--- a/docs/okta_obo_for_an_enterprise_mcp_gateway.md
+++ b/docs/okta_obo_for_an_enterprise_mcp_gateway.md
@@ -1,0 +1,237 @@
+## Okta OBO (On-Behalf-Of) Explained for an Enterprise MCP Gateway
+
+This document explains **On-Behalf-Of (OBO)** token exchange in the specific context of:
+- Okta as the IdP
+- An Enterprise MCP Gateway deployed in the enterprise network
+- A requirement to execute MCP tool calls **as the current user**
+
+---
+
+## 1) What OBO Is (Precise Definition)
+
+**OBO is a delegated-authorization pattern** where a trusted backend exchanges a **user token** issued for one audience (resource) into a **new user token** issued for a different audience (downstream resource).
+
+The result is a downstream call that:
+- still represents the same user
+- is constrained by the user’s delegated permissions
+- is valid for the downstream system (correct audience/scope)
+
+---
+
+## 2) Why OBO Exists (Problem OBO Solves)
+
+In enterprises, a user token is usually minted for a specific resource (audience), such as:
+- enterprise-ai
+- internal-agent
+- chat-tool
+
+Downstream APIs/MCP servers typically require tokens minted for *their* audience, such as:
+- github-mcp
+- internal-infra-mcp
+- jira-mcp
+
+If you forward the original token, the downstream resource may reject it (wrong audience/scopes). If you use a service account, you lose user attribution and least privilege.
+
+OBO is the standard way to preserve user identity and permissions across service boundaries.
+
+---
+
+## 3) OBO in MCP Gateway Terms
+
+### Actors
+- **User**: authenticates interactively
+- **Enterprise AI Tool**: primary client UX
+- **Okta**: authorization server
+- **MCP Gateway**: trusted intermediary
+- **MCP Server**: downstream resource/API
+
+### Tokens
+- **Token A**: user token for the Enterprise AI Tool audience
+- **Token B**: user token for the MCP server audience (minted via OBO)
+
+---
+
+## 4) End-to-End Sequence Diagram (Recommended Pattern)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant A as Enterprise AI Tool
+    participant O as Okta Authorization Server
+    participant G as MCP Gateway
+    participant S as MCP Server (Downstream)
+
+    U->>A: Sign in (interactive)
+    A->>O: OAuth2 Authorization Code
+    O-->>A: Access Token A (aud=enterprise-ai)
+
+    A->>G: MCP request + Token A
+    G->>G: Validate Token A (sig/iss/aud/exp)
+    G->>G: Evaluate policy (server/tool/user/group)
+    G->>G: Inline mask input (Presidio)
+
+    G->>O: Token Exchange (OBO) using Token A
+    O-->>G: Access Token B (aud=mcp-server, scoped)
+
+    G->>S: MCP call + Token B (as user)
+    S-->>G: MCP response
+
+    G->>G: Inline mask output (Presidio)
+    G-->>A: Response (masked) + audit log emitted
+```
+
+---
+
+## 4.5) Transport Applicability
+
+OBO token exchange is designed for service-to-service boundaries. Its applicability depends on the MCP transport:
+
+### HTTP-based MCP servers
+- OBO applies directly — the gateway exchanges the user's token for a downstream token scoped to the MCP server's audience
+- This is the primary OBO use case described in this document
+
+### stdio-based MCP servers (gateway-managed)
+- The MCP server runs as a subprocess of the gateway — there is no network boundary or separate audience
+- OBO token exchange is **not needed** for stdio servers; the gateway propagates user identity via its own process context
+- Governance and audit attribution are maintained by the gateway wrapping all stdio communication with the same policy evaluation and audit pipeline
+- If a stdio-managed MCP server needs to make its own downstream HTTP calls, the gateway can provide delegated credentials through environment or configuration
+
+### Key principle
+Governance and audit attribution are maintained regardless of transport. OBO solves the specific problem of crossing audience boundaries over HTTP; stdio servers under gateway management do not cross that boundary.
+
+---
+
+## 5) Forward vs Exchange (Decision Rule)
+
+### Forward the user token (Token A) when:
+- the MCP server accepts Token A (correct audience)
+- the resource server trusts the same Okta authorization server
+- scopes/claims are already sufficient
+
+### Use OBO token exchange when:
+- the MCP server requires a different audience
+- you need different scopes
+- you need stricter isolation per downstream system
+- you are calling external/third-party MCP servers behind an API gateway
+
+### stdio transport (gateway-managed servers):
+- Token forwarding and exchange are **not applicable** — the server runs as a gateway subprocess
+- User identity is maintained via the gateway's process context
+- If the stdio server needs to call downstream HTTP APIs, the gateway can inject delegated credentials via environment or configuration
+
+Practical enterprise default: **prefer exchange** for HTTP downstream calls; **rely on gateway process context** for stdio servers.
+
+---
+
+## 6) Good vs Bad Examples
+
+### Good Example: OBO (Delegated User)
+**Scenario:** Developer uses MCP to read GitHub issues.
+- User logs into enterprise AI tool
+- Gateway validates user
+- Gateway exchanges for a github-mcp token
+- GitHub MCP server logs action as the user
+
+**Why it’s good**
+- Attribution preserved
+- Least privilege enforced
+- Auditable by user/group/scope
+
+---
+
+### Bad Example: Service Account (Non-Delegated)
+**Scenario:** Gateway uses a single service account to call all MCP servers.
+
+**What goes wrong**
+- Downstream systems see “gateway-service” not the user
+- Audits cannot prove who did what
+- A compromise becomes catastrophic (broad permissions)
+- Security teams will block this model
+
+---
+
+### Bad Example: Forwarding Wrong-Audience Tokens
+**Scenario:** Gateway forwards Token A to a downstream system expecting Token B.
+
+**What goes wrong**
+- Downstream rejects calls (audience mismatch)
+- Teams work around by disabling token checks
+- Security posture degrades
+
+---
+
+## 7) Security Explainer (How to Defend OBO)
+
+### What Security Usually Asks
+1. Does this preserve user identity?
+2. Can the gateway mint tokens for any user?
+3. Is privilege constrained per resource?
+4. Is this auditable?
+
+### Security Answers
+- OBO **requires a real user token** as the assertion.
+- The gateway cannot act for users who are not authenticated.
+- The authorization server enforces:
+  - which clients can perform exchange
+  - which audiences are allowed
+  - which scopes are granted
+- Every request can be logged:
+  - original user identity
+  - target audience/scope
+  - policy decision
+
+### Security Posture Summary
+OBO is **delegated authorization**, not impersonation.
+
+---
+
+## 8) Okta-Specific Implementation Notes (Conceptual)
+
+To support OBO in Okta, you typically need:
+- A **Custom Authorization Server** (API Access Management)
+- Token exchange enabled/allowed for the gateway client
+- Audience and scope design per MCP server
+- Group claims configured (if governance relies on groups)
+
+Your gateway should treat Okta as the token issuer and be able to:
+- validate incoming access tokens (JWT validation)
+- exchange tokens for downstream audiences
+- cache exchange results safely (short TTL)
+
+---
+
+## 9) Operational & Failure Modes
+
+### If token exchange fails
+- Deny the request
+- Emit an audit event with reason
+
+### If Presidio fails
+- Recommended default: deny (fail closed) for external MCP servers
+- Log reason and correlation ID
+
+### If policy file invalid
+- Fail startup
+- Prevent silent permissive behavior
+
+---
+
+## 10) Practical Guidance for Your MCP Gateway MVP
+
+MVP recommendation:
+- Implement exchange as a pluggable module
+- Support per-server configuration:
+  - forward vs exchange
+  - target audience
+  - required scopes
+- Log both:
+  - upstream user token subject
+  - downstream audience/scope
+
+---
+
+## 11) Short Executive Explanation
+
+“OBO lets the gateway call downstream MCP servers with a token that represents the same user, but scoped and audience-bound to that downstream system, so Security can approve MCP usage without losing attribution or least privilege.”
+

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,108 @@
+## Product Requirements Document (PRD)
+
+### Title  
+Enterprise MCP Gateway for Governance, Auditing, and Data Protection
+
+### Author  
+Bryan
+
+### Version  
+1.0 (MVP)
+
+---
+
+### Summary  
+The Enterprise MCP Gateway is a centrally hosted, cloud-based gateway deployed inside the enterprise network that enables secure, compliant use of the Model Context Protocol (MCP) in regulated environments.
+
+Its primary goal is to unblock MCP adoption for enterprise AI tools by providing:
+- Governance controls over which MCP servers and tools may be used
+- User-scoped authorization using OAuth2 (acting as the current user)
+- Comprehensive auditing and logging for security and compliance
+- Inline data protection via secret and PII masking using Microsoft Presidio
+
+The gateway provides hard enforcement for hosted enterprise AI tools and observability-only coverage for local developer usage, acknowledging technical limits while still delivering compliance value.
+
+---
+
+### Core User Flow  
+1. User interacts with an enterprise AI tool.
+2. User authenticates via OAuth2 (Okta).
+3. AI tool sends MCP requests through the gateway.
+4. Gateway authenticates, evaluates policy, masks sensitive data, and proxies request as user.
+5. MCP server executes and returns response.
+6. Gateway masks response, logs audit event, and returns output.
+
+---
+
+### Functional Requirements  
+
+#### Identity & Authentication
+- Okta integration
+- OAuth2 Authorization Code flow (primary)
+- Gateway acts on behalf of the user
+
+#### Governance
+- Static YAML/JSON policy configuration
+- Allow/deny by server, tool, user/group/role
+- Synchronous policy evaluation
+
+#### MCP Support
+- Full MCP spec support (tools, resources, prompts, sampling)
+- Streamable HTTP and stdio transport
+- First- and third-party MCP servers
+- Best-effort compatibility with MCP spec changes
+
+#### Auditing & Logging
+- Structured audit logs including user, tool, policy decision, timestamps
+- Logs emitted via stdout
+
+#### Data Protection
+- Inline Presidio masking on inputs and outputs
+- Mask PII and secrets
+- Masked-only persistence
+
+#### Enforcement
+- Hard enforcement for hosted enterprise tools
+- Observability-only for local usage
+
+#### Transport & Enforcement Model
+- **HTTP / Streamable HTTP**: primary enforcement path — full governance, OBO token exchange, data masking, and auditing
+- **stdio (gateway-managed)**: supported for gateway-spawned MCP server processes — governed and audited when invoked through hosted enterprise AI tools
+- **Local developer stdio**: observability-only — local stdio-based MCP usage outside the gateway is not enforced; monitored through complementary controls
+
+---
+
+### Expected Behavior  
+- Disallowed tools are blocked
+- Sensitive data is masked before leaving the enterprise boundary
+- All actions are logged
+
+---
+
+### Design / UI Components  
+- MVP: No UI (config + logs)
+- Future: Admin console, approvals, dynamic policy
+
+---
+
+### Acceptance Criteria (Gherkin)
+```gherkin
+Given an authenticated user
+When the user invokes an allowed MCP tool
+Then the gateway forwards the request as the user
+And masks sensitive data inline
+And logs the action with policy decision "allow"
+
+Given an authenticated user
+When the user invokes a disallowed MCP tool
+Then the gateway blocks the request
+And logs the action with policy decision "deny"
+```
+
+---
+
+### Success Metrics  
+- MCP adoption in enterprise AI tools
+- 100% audited MCP traffic
+- Zero unmasked sensitive data in logs
+


### PR DESCRIPTION
## Summary

- Add explicit stdio transport support alongside Streamable HTTP across all 8 MCP gateway documentation files
- Establish consistent enforcement boundary: gateway-managed traffic (HTTP or stdio) is enforced, local developer stdio is observability-only
- Add transport abstraction stories to implementation plan, server registry to policy schema, and stdio threat coverage to threat model

## Changes

- **PRD**: Updated MCP Support section; added Transport & Enforcement Model subsection
- **Architecture Diagram**: Updated mermaid diagram with HTTP + stdio server types; added Transport Model section
- **Implementation Plan**: Added stdio transport and abstraction layer stories to Epic 1; updated Phase 0 scope
- **Leadership Explainer**: Added transport mention; expanded Enforcement Reality per transport
- **Policy Schema**: Added `servers` registry with transport/URL/command config; added stdio policy example
- **Security Compliance**: Added governance note for both transports; expanded Enforcement Model to three tiers
- **Threat Model**: Added stdio Server Governance threat (mitigated); expanded local developer threat to include stdio
- **OBO Document**: Added Section 4.5 Transport Applicability; added stdio case to Forward vs Exchange

## Motivation

The existing documentation exclusively referenced Streamable HTTP. Real-world MCP server implementations use both HTTP and stdio transports. This update brings docs in line with actual MCP ecosystem requirements while preserving the enforcement vs. observability boundary.

## Testing

- Read through each file for internal consistency
- Verified enforcement boundary is consistently described across all 8 documents
- Mermaid diagram updated with both transport paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)