### PR TITLE
feat: add correlation ID propagation throughout request lifecycle

### DIFF
--- a/src/mcp_zero/context.py
+++ b/src/mcp_zero/context.py
@@ -13,13 +13,29 @@ from typing import Any
 class RequestContext:
     """Per-request context carrying correlation ID and user identity.
 
-    Stories #11/#12 will extend this with full identity propagation.
+    Each request gets a unique ``correlation_id``.  A ``trace_id`` groups
+    parent-child calls together — it defaults to the ``correlation_id`` of the
+    root request and is inherited by child contexts.
     """
 
     correlation_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    trace_id: str = ""
     user_id: str | None = None
     user_email: str | None = None
     user_groups: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.trace_id:
+            object.__setattr__(self, "trace_id", self.correlation_id)
+
+    def child_context(self) -> RequestContext:
+        """Create a child context with a new correlation ID but the same trace."""
+        return RequestContext(
+            trace_id=self.trace_id,
+            user_id=self.user_id,
+            user_email=self.user_email,
+            user_groups=list(self.user_groups),
+        )
 
 
 class PolicyDecision(StrEnum):

--- a/src/mcp_zero/transport/errors.py
+++ b/src/mcp_zero/transport/errors.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 class TransportError(Exception):
     """Base error for all transport operations."""
 
-    def __init__(self, message: str, *, server_name: str = "") -> None:
+    def __init__(self, message: str, *, server_name: str = "", correlation_id: str = "") -> None:
         self.server_name = server_name
+        self.correlation_id = correlation_id
         super().__init__(message)
 
 

--- a/src/mcp_zero/transport/http.py
+++ b/src/mcp_zero/transport/http.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextlib import AsyncExitStack
 
+import httpx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 
@@ -26,11 +27,28 @@ class StreamableHTTPTransport(MCPTransport):
         if self._state == TransportState.CONNECTED:
             return
 
+        cid = context.correlation_id if context else ""
         self._state = TransportState.CONNECTING
         try:
             stack = AsyncExitStack()
+
+            # Inject correlation / trace headers when a context is available.
+            http_client: httpx.AsyncClient | None = None
+            if context:
+                http_client = await stack.enter_async_context(
+                    httpx.AsyncClient(
+                        headers={
+                            "X-Correlation-ID": context.correlation_id,
+                            "X-Trace-ID": context.trace_id,
+                        }
+                    )
+                )
+
             read_stream, write_stream, _ = await stack.enter_async_context(
-                streamable_http_client(self._config.url)  # type: ignore[arg-type]
+                streamable_http_client(
+                    self._config.url,  # type: ignore[arg-type]
+                    http_client=http_client,
+                )
             )
             session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
             await session.initialize()
@@ -46,12 +64,14 @@ class StreamableHTTPTransport(MCPTransport):
             raise TransportConnectionError(
                 f"Failed to connect to '{self._config.name}' at {self._config.url}: {exc}",
                 server_name=self._config.name,
+                correlation_id=cid,
             ) from exc
         except Exception as exc:
             self._state = TransportState.ERROR
             raise SessionError(
                 f"Session error for '{self._config.name}': {exc}",
                 server_name=self._config.name,
+                correlation_id=cid,
             ) from exc
 
     async def disconnect(self) -> None:

--- a/src/mcp_zero/transport/stdio.py
+++ b/src/mcp_zero/transport/stdio.py
@@ -26,13 +26,18 @@ class StdioTransport(MCPTransport):
         if self._state == TransportState.CONNECTED:
             return
 
+        cid = context.correlation_id if context else ""
         self._state = TransportState.CONNECTING
         try:
             env = dict(self._config.env) if self._config.env else None
             if context and env is not None:
                 env["MCP_CORRELATION_ID"] = context.correlation_id
+                env["MCP_TRACE_ID"] = context.trace_id
             elif context:
-                env = {"MCP_CORRELATION_ID": context.correlation_id}
+                env = {
+                    "MCP_CORRELATION_ID": context.correlation_id,
+                    "MCP_TRACE_ID": context.trace_id,
+                }
 
             params = StdioServerParameters(
                 command=self._config.command,  # type: ignore[arg-type]
@@ -53,6 +58,7 @@ class StdioTransport(MCPTransport):
             raise ProcessError(
                 f"Failed to spawn '{self._config.command}' for '{self._config.name}': {exc}",
                 server_name=self._config.name,
+                correlation_id=cid,
             ) from exc
         except (TransportConnectionError, ProcessError):
             self._state = TransportState.ERROR
@@ -62,12 +68,14 @@ class StdioTransport(MCPTransport):
             raise TransportConnectionError(
                 f"Failed to connect to '{self._config.name}': {exc}",
                 server_name=self._config.name,
+                correlation_id=cid,
             ) from exc
         except Exception as exc:
             self._state = TransportState.ERROR
             raise SessionError(
                 f"Session error for '{self._config.name}': {exc}",
                 server_name=self._config.name,
+                correlation_id=cid,
             ) from exc
 
     async def disconnect(self) -> None:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,60 @@
+"""Tests for RequestContext."""
+
+import re
+
+import pytest
+
+from mcp_zero.context import RequestContext
+
+UUID4_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+
+class TestRequestContext:
+    def test_correlation_id_is_uuid4(self):
+        ctx = RequestContext()
+        assert UUID4_RE.match(ctx.correlation_id)
+
+    def test_trace_id_defaults_to_correlation_id(self):
+        ctx = RequestContext()
+        assert ctx.trace_id == ctx.correlation_id
+
+    def test_explicit_trace_id_preserved(self):
+        ctx = RequestContext(trace_id="my-trace")
+        assert ctx.trace_id == "my-trace"
+        assert ctx.trace_id != ctx.correlation_id
+
+    def test_frozen_immutability(self):
+        ctx = RequestContext()
+        with pytest.raises(AttributeError):
+            ctx.correlation_id = "new"  # type: ignore[misc]
+        with pytest.raises(AttributeError):
+            ctx.trace_id = "new"  # type: ignore[misc]
+
+    def test_unique_ids_across_instances(self):
+        a = RequestContext()
+        b = RequestContext()
+        assert a.correlation_id != b.correlation_id
+
+    def test_child_context_new_correlation_id(self):
+        parent = RequestContext()
+        child = parent.child_context()
+        assert child.correlation_id != parent.correlation_id
+        assert UUID4_RE.match(child.correlation_id)
+
+    def test_child_context_inherits_trace_id(self):
+        parent = RequestContext()
+        child = parent.child_context()
+        assert child.trace_id == parent.trace_id
+
+    def test_child_context_inherits_user_identity(self):
+        parent = RequestContext(user_id="u1", user_email="u@x.com", user_groups=["admin"])
+        child = parent.child_context()
+        assert child.user_id == "u1"
+        assert child.user_email == "u@x.com"
+        assert child.user_groups == ["admin"]
+
+    def test_child_context_groups_are_copied(self):
+        parent = RequestContext(user_groups=["a", "b"])
+        child = parent.child_context()
+        assert child.user_groups is not parent.user_groups
+        assert child.user_groups == ["a", "b"]

--- a/tests/transport/test_errors.py
+++ b/tests/transport/test_errors.py
@@ -38,6 +38,26 @@ class TestErrorHierarchy:
         err = ProcessError("not found", server_name="local-tool")
         assert err.server_name == "local-tool"
 
+    def test_correlation_id_default(self):
+        err = TransportError("fail")
+        assert err.correlation_id == ""
+
+    def test_correlation_id_stored(self):
+        err = TransportError("fail", correlation_id="abc-123")
+        assert err.correlation_id == "abc-123"
+
+    def test_subclasses_accept_correlation_id(self):
+        for cls in (
+            TransportConnectionError,
+            TransportTimeoutError,
+            SessionError,
+            TransportClosedError,
+            ProcessError,
+        ):
+            err = cls("msg", server_name="s", correlation_id="cid-1")
+            assert err.correlation_id == "cid-1"
+            assert err.server_name == "s"
+
     def test_catchable_as_base(self):
         try:
             raise TransportConnectionError("refused", server_name="x")

--- a/tests/transport/test_http.py
+++ b/tests/transport/test_http.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from mcp_zero.context import RequestContext
 from mcp_zero.transport.base import TransportState
 from mcp_zero.transport.config import ServerConfig, TransportType
 from mcp_zero.transport.errors import SessionError, TransportClosedError, TransportConnectionError
@@ -63,7 +64,7 @@ class TestStreamableHTTPTransport:
 
         assert t.state == TransportState.CONNECTED
         assert t.session is mock_sdk["session"]
-        mock_sdk["client"].assert_called_once_with(cfg.url)
+        mock_sdk["client"].assert_called_once_with(cfg.url, http_client=None)
         mock_sdk["session"].initialize.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -115,6 +116,48 @@ class TestStreamableHTTPTransport:
         with pytest.raises(SessionError, match="protocol mismatch"):
             await t.connect()
         assert t.state == TransportState.ERROR
+
+    @pytest.mark.asyncio
+    async def test_connect_with_context_passes_http_client(self, mock_sdk):
+        cfg = make_http_config()
+        ctx = RequestContext(correlation_id="c-1", trace_id="t-1")
+        t = StreamableHTTPTransport(cfg)
+
+        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+            mock_httpx_inst = AsyncMock()
+            mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
+            mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.return_value = mock_httpx_inst
+
+            await t.connect(context=ctx)
+
+            mock_httpx.assert_called_once_with(
+                headers={"X-Correlation-ID": "c-1", "X-Trace-ID": "t-1"}
+            )
+            # httpx client instance passed to streamable_http_client
+            call_kwargs = mock_sdk["client"].call_args[1]
+            assert call_kwargs["http_client"] is mock_httpx_inst
+
+    @pytest.mark.asyncio
+    async def test_connect_without_context_no_http_client(self, mock_sdk):
+        cfg = make_http_config()
+        t = StreamableHTTPTransport(cfg)
+
+        await t.connect()
+
+        call_kwargs = mock_sdk["client"].call_args[1]
+        assert call_kwargs["http_client"] is None
+
+    @pytest.mark.asyncio
+    async def test_error_carries_correlation_id(self, mock_sdk):
+        mock_sdk["client"].return_value.__aenter__.side_effect = OSError("refused")
+        cfg = make_http_config()
+        ctx = RequestContext(correlation_id="err-cid")
+        t = StreamableHTTPTransport(cfg)
+
+        with pytest.raises(TransportConnectionError) as exc_info:
+            await t.connect(context=ctx)
+        assert exc_info.value.correlation_id == "err-cid"
 
     @pytest.mark.asyncio
     async def test_context_manager(self, mock_sdk):

--- a/tests/transport/test_stdio.py
+++ b/tests/transport/test_stdio.py
@@ -91,9 +91,20 @@ class TestStdioTransport:
         assert call_args.env["MCP_CORRELATION_ID"] == "test-123"
 
     @pytest.mark.asyncio
+    async def test_connect_injects_trace_id(self, mock_sdk):
+        cfg = make_stdio_config()
+        ctx = RequestContext(correlation_id="c-1", trace_id="t-1")
+        t = StdioTransport(cfg)
+
+        await t.connect(context=ctx)
+
+        call_args = mock_sdk["client"].call_args[0][0]
+        assert call_args.env["MCP_TRACE_ID"] == "t-1"
+
+    @pytest.mark.asyncio
     async def test_connect_merges_env_with_correlation(self, mock_sdk):
         cfg = make_stdio_config(env={"EXISTING": "value"})
-        ctx = RequestContext(correlation_id="corr-456")
+        ctx = RequestContext(correlation_id="corr-456", trace_id="trace-789")
         t = StdioTransport(cfg)
 
         await t.connect(context=ctx)
@@ -101,6 +112,7 @@ class TestStdioTransport:
         call_args = mock_sdk["client"].call_args[0][0]
         assert call_args.env["EXISTING"] == "value"
         assert call_args.env["MCP_CORRELATION_ID"] == "corr-456"
+        assert call_args.env["MCP_TRACE_ID"] == "trace-789"
 
     @pytest.mark.asyncio
     async def test_connect_idempotent(self, mock_sdk):
@@ -160,6 +172,17 @@ class TestStdioTransport:
         with pytest.raises(SessionError, match="bad handshake"):
             await t.connect()
         assert t.state == TransportState.ERROR
+
+    @pytest.mark.asyncio
+    async def test_error_carries_correlation_id(self, mock_sdk):
+        mock_sdk["client"].return_value.__aenter__.side_effect = FileNotFoundError("gone")
+        cfg = make_stdio_config()
+        ctx = RequestContext(correlation_id="err-cid")
+        t = StdioTransport(cfg)
+
+        with pytest.raises(ProcessError) as exc_info:
+            await t.connect(context=ctx)
+        assert exc_info.value.correlation_id == "err-cid"
 
     @pytest.mark.asyncio
     async def test_context_manager(self, mock_sdk):


### PR DESCRIPTION
## Summary

Implements complete correlation ID propagation throughout the MCP request lifecycle, enabling end-to-end request tracing across parent-child call chains, HTTP headers, stdio env vars, and error responses.

## Changes

- **`RequestContext`**: Added `trace_id` field (defaults to `correlation_id`) and `child_context()` method for parent-child trace chains
- **`TransportError`**: Added `correlation_id` keyword param (default `""`) inherited by all subclasses
- **`StreamableHTTPTransport`**: Injects `X-Correlation-ID` and `X-Trace-ID` headers via `httpx.AsyncClient` when context is provided; attaches `correlation_id` to errors
- **`StdioTransport`**: Injects `MCP_TRACE_ID` env var alongside existing `MCP_CORRELATION_ID`; attaches `correlation_id` to errors
- **Tests**: 9 new `RequestContext` tests, 3 new error tests, 3 new HTTP transport tests, 2 new stdio transport tests (62 total, all passing)

## Motivation

Issue #12 requires correlation IDs to flow through the entire request lifecycle so that downstream MCP servers, audit logs, and error responses can be correlated back to the originating request. This is foundational for the gateway's governance and auditing capabilities.

## Testing

```bash
scripts\test.bat -v    # 62 tests pass
scripts\lint.bat       # ruff check passes
scripts\format.bat     # ruff format passes
```

## Related Issues

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)