### PR TITLE
feat: add policy evaluation engine (#17)

### DIFF
--- a/src/mcp_zero/governance/__init__.py
+++ b/src/mcp_zero/governance/__init__.py
@@ -1,4 +1,4 @@
-"""Governance policy file loading and validation."""
+"""Governance policy file loading, validation, and evaluation."""
 
 from mcp_zero.governance.config import (
     IdentityProviderConfig,
@@ -11,6 +11,11 @@ from mcp_zero.governance.config import (
     PolicySubjects,
     PresidioConfig,
     ServerDefinition,
+)
+from mcp_zero.governance.engine import (
+    EvaluationResult,
+    PolicyEngine,
+    PolicyInput,
 )
 from mcp_zero.governance.errors import (
     GovernanceError,
@@ -25,13 +30,16 @@ from mcp_zero.governance.loader import (
 )
 
 __all__ = [
+    "EvaluationResult",
     "GovernanceError",
     "IdentityProviderConfig",
     "LoggingConfig",
     "MaskingConfig",
     "PolicyConfig",
     "PolicyEffect",
+    "PolicyEngine",
     "PolicyFileError",
+    "PolicyInput",
     "PolicyReferenceError",
     "PolicyRule",
     "PolicyServerAccess",

--- a/src/mcp_zero/governance/engine.py
+++ b/src/mcp_zero/governance/engine.py
@@ -1,0 +1,212 @@
+"""Policy evaluation engine.
+
+Evaluates governance policy rules against a request to produce an allow/deny
+decision.  Rules are evaluated top-down (file order matters), with explicit deny
+overriding allow regardless of position.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from mcp_zero.governance.config import (
+    PolicyConfig,
+    PolicyEffect,
+    PolicyRule,
+    PolicyServerAccess,
+    PolicySubjects,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Input / Output data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PolicyInput:
+    """Input for policy evaluation.
+
+    Args:
+        user_id: Authenticated user identifier.
+        groups: Group memberships resolved from the identity token.
+        mcp_server: Target MCP server name.
+        tool: Tool being invoked.
+    """
+
+    user_id: str
+    groups: list[str] = field(default_factory=list)
+    mcp_server: str = ""
+    tool: str = ""
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    """Result of a policy evaluation.
+
+    Args:
+        effect: The decision — ``allow`` or ``deny``.
+        policy_id: ID of the policy rule that matched (``None`` when defaulting).
+        reason: Human-readable reason (populated on deny or error).
+    """
+
+    effect: PolicyEffect
+    policy_id: str | None = None
+    reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Pattern matching helpers
+# ---------------------------------------------------------------------------
+
+
+def _matches_pattern(pattern: str, value: str) -> bool:
+    """Match *value* against a wildcard *pattern*.
+
+    Supported patterns:
+    - ``*`` — matches everything.
+    - ``prefix*`` — matches values starting with *prefix*.
+    - ``*suffix`` — matches values ending with *suffix*.
+    - Otherwise — exact match.
+    """
+    if pattern == "*":
+        return True
+    if pattern.endswith("*"):
+        return value.startswith(pattern[:-1])
+    if pattern.startswith("*"):
+        return value.endswith(pattern[1:])
+    return pattern == value
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class PolicyEngine:
+    """Evaluates loaded policy rules against a request.
+
+    Evaluation semantics:
+
+    1. Rules are scanned top-down in file order.
+    2. A rule *matches* when both its **subjects** and at least one of its
+       **mcp_servers** entries match the input.
+    3. **Deny overrides allow**: if *any* matching rule has effect ``deny``,
+       the request is denied — regardless of whether an ``allow`` rule also
+       matches or appears earlier in the file.
+    4. If only ``allow`` rules match, the first one determines the decision.
+    5. When no rule matches, the policy-level ``default`` effect is used.
+    6. Any exception during evaluation results in a ``deny`` (fail closed).
+    """
+
+    def __init__(self, policy: PolicyConfig) -> None:
+        self._policy = policy
+
+    def evaluate(self, policy_input: PolicyInput) -> EvaluationResult:
+        """Evaluate the loaded policy against *policy_input*.
+
+        Returns an :class:`EvaluationResult` that is always ``allow`` or
+        ``deny`` — never an error enum.  Errors are surfaced as ``deny``
+        with a descriptive *reason* (fail-closed).
+        """
+        try:
+            return self._evaluate_rules(policy_input)
+        except Exception as exc:
+            logger.exception("Policy evaluation error (fail closed)")
+            return EvaluationResult(
+                effect=PolicyEffect.DENY,
+                reason=f"Evaluation error: {exc}",
+            )
+
+    # ------------------------------------------------------------------
+    # Internal evaluation
+    # ------------------------------------------------------------------
+
+    def _evaluate_rules(self, policy_input: PolicyInput) -> EvaluationResult:
+        first_allow: PolicyRule | None = None
+        first_deny: PolicyRule | None = None
+
+        for rule in self._policy.policies:
+            if not self._rule_matches(rule, policy_input):
+                continue
+
+            if rule.effect == PolicyEffect.DENY and first_deny is None:
+                first_deny = rule
+            elif rule.effect == PolicyEffect.ALLOW and first_allow is None:
+                first_allow = rule
+
+        # Deny overrides allow
+        if first_deny is not None:
+            return EvaluationResult(
+                effect=PolicyEffect.DENY,
+                policy_id=first_deny.id,
+                reason=first_deny.description,
+            )
+
+        if first_allow is not None:
+            return EvaluationResult(
+                effect=PolicyEffect.ALLOW,
+                policy_id=first_allow.id,
+            )
+
+        # No matching rule — fall back to the policy default
+        default = self._policy.default
+        reason = "No matching policy; default is deny" if default == PolicyEffect.DENY else None
+        return EvaluationResult(effect=default, reason=reason)
+
+    # ------------------------------------------------------------------
+    # Matching helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _rule_matches(rule: PolicyRule, policy_input: PolicyInput) -> bool:
+        """A rule matches when subjects AND at least one server/tool entry match."""
+        if not PolicyEngine._subjects_match(rule.subjects, policy_input):
+            return False
+        return PolicyEngine._servers_match(rule.mcp_servers, policy_input)
+
+    @staticmethod
+    def _subjects_match(subjects: PolicySubjects, policy_input: PolicyInput) -> bool:
+        """Check whether *policy_input* satisfies the rule's subject constraints.
+
+        An empty/missing subjects field (no users, no groups) is treated as
+        matching everyone — this allows blanket rules without enumerating
+        subjects.
+        """
+        if not subjects.users and not subjects.groups:
+            return True
+
+        # Direct user match
+        if policy_input.user_id in subjects.users:
+            return True
+
+        # Group intersection (including wildcard ``*``)
+        if "*" in subjects.groups:
+            return True
+        if set(policy_input.groups) & set(subjects.groups):
+            return True
+
+        return False
+
+    @staticmethod
+    def _servers_match(mcp_servers: list[PolicyServerAccess], policy_input: PolicyInput) -> bool:
+        """Check whether any server access entry matches the input."""
+        for access in mcp_servers:
+            if _matches_pattern(access.name, policy_input.mcp_server):
+                if PolicyEngine._tools_match(access.tools, policy_input.tool):
+                    return True
+        return False
+
+    @staticmethod
+    def _tools_match(tool_patterns: list[str], tool_name: str) -> bool:
+        """Check whether *tool_name* matches any of the *tool_patterns*.
+
+        An empty patterns list is treated as matching all tools for that
+        server entry.
+        """
+        if not tool_patterns:
+            return True
+        return any(_matches_pattern(p, tool_name) for p in tool_patterns)

--- a/src/mcp_zero/governance/loader.py
+++ b/src/mcp_zero/governance/loader.py
@@ -381,10 +381,17 @@ def _build_masking(data: dict) -> MaskingConfig:
 
 
 def _validate_cross_references(policy: PolicyConfig) -> None:
-    """Check that server names in policies exist in the servers list."""
+    """Check that server names in policies exist in the servers list.
+
+    Server names that contain wildcards (``*``, ``prefix*``, ``*suffix``) are
+    skipped because they match dynamically at evaluation time rather than
+    referencing a specific server definition.
+    """
     server_names = {s.name for s in policy.servers}
     for rule in policy.policies:
         for access in rule.mcp_servers:
+            if "*" in access.name:
+                continue
             if access.name not in server_names:
                 raise PolicyReferenceError(
                     f"Policy '{rule.id}' references unknown server '{access.name}'",

--- a/tests/governance/test_engine.py
+++ b/tests/governance/test_engine.py
@@ -1,0 +1,678 @@
+"""Tests for the policy evaluation engine."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_zero.governance.config import (
+    PolicyConfig,
+    PolicyEffect,
+    PolicyRule,
+    PolicyServerAccess,
+    PolicySubjects,
+)
+from mcp_zero.governance.engine import (
+    EvaluationResult,
+    PolicyEngine,
+    PolicyInput,
+    _matches_pattern,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _policy(
+    *rules: PolicyRule,
+    default: PolicyEffect = PolicyEffect.DENY,
+) -> PolicyConfig:
+    """Build a minimal PolicyConfig with the given rules."""
+    return PolicyConfig(version=1, default=default, policies=list(rules))
+
+
+def _rule(
+    rule_id: str,
+    effect: PolicyEffect,
+    *,
+    users: list[str] | None = None,
+    groups: list[str] | None = None,
+    servers: list[PolicyServerAccess] | None = None,
+) -> PolicyRule:
+    """Build a PolicyRule with sensible defaults."""
+    subjects = PolicySubjects(
+        users=users or [],
+        groups=groups or [],
+    )
+    return PolicyRule(
+        id=rule_id,
+        description=f"Rule {rule_id}",
+        effect=effect,
+        subjects=subjects,
+        mcp_servers=servers or [],
+    )
+
+
+def _server(name: str, tools: list[str] | None = None) -> PolicyServerAccess:
+    """Build a PolicyServerAccess entry."""
+    return PolicyServerAccess(name=name, tools=tools or [])
+
+
+def _input(
+    user_id: str = "user@example.com",
+    groups: list[str] | None = None,
+    mcp_server: str = "api",
+    tool: str = "read_file",
+) -> PolicyInput:
+    return PolicyInput(
+        user_id=user_id,
+        groups=groups or [],
+        mcp_server=mcp_server,
+        tool=tool,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _matches_pattern unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesPattern:
+    def test_wildcard_matches_everything(self):
+        assert _matches_pattern("*", "anything") is True
+        assert _matches_pattern("*", "") is True
+
+    def test_prefix_wildcard(self):
+        assert _matches_pattern("read_*", "read_file") is True
+        assert _matches_pattern("read_*", "read_") is True
+        assert _matches_pattern("read_*", "write_file") is False
+
+    def test_suffix_wildcard(self):
+        assert _matches_pattern("*_file", "read_file") is True
+        assert _matches_pattern("*_file", "_file") is True
+        assert _matches_pattern("*_file", "read_config") is False
+
+    def test_exact_match(self):
+        assert _matches_pattern("read_file", "read_file") is True
+        assert _matches_pattern("read_file", "write_file") is False
+
+    def test_hyphen_in_pattern(self):
+        assert _matches_pattern("internal-*", "internal-infra") is True
+        assert _matches_pattern("internal-*", "external-infra") is False
+
+
+# ---------------------------------------------------------------------------
+# Subject matching
+# ---------------------------------------------------------------------------
+
+
+class TestSubjectMatching:
+    def test_empty_subjects_matches_everyone(self):
+        """A rule with no users/groups matches all requests."""
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+        result = engine.evaluate(_input(user_id="anyone"))
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id == "r1"
+
+    def test_user_id_match(self):
+        policy = _policy(
+            _rule(
+                "r1",
+                PolicyEffect.ALLOW,
+                users=["alice@corp.com"],
+                servers=[_server("api", ["*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(user_id="alice@corp.com")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(user_id="bob@corp.com")).effect == PolicyEffect.DENY
+
+    def test_group_intersection(self):
+        policy = _policy(
+            _rule(
+                "r1",
+                PolicyEffect.ALLOW,
+                groups=["admins", "sre"],
+                servers=[_server("api", ["*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        # User in one matching group
+        result = engine.evaluate(_input(groups=["admins"]))
+        assert result.effect == PolicyEffect.ALLOW
+
+        # User in both matching groups
+        result = engine.evaluate(_input(groups=["admins", "sre"]))
+        assert result.effect == PolicyEffect.ALLOW
+
+        # User in unrelated group
+        result = engine.evaluate(_input(groups=["developers"]))
+        assert result.effect == PolicyEffect.DENY
+
+    def test_wildcard_group(self):
+        """The group ``*`` should match any user regardless of their groups."""
+        policy = _policy(
+            _rule(
+                "r1",
+                PolicyEffect.DENY,
+                groups=["*"],
+                servers=[_server("api", ["*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input(groups=[]))
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id == "r1"
+
+        result = engine.evaluate(_input(groups=["random"]))
+        assert result.effect == PolicyEffect.DENY
+
+    def test_user_match_without_group_match(self):
+        """User ID match is sufficient even if groups don't overlap."""
+        policy = _policy(
+            _rule(
+                "r1",
+                PolicyEffect.ALLOW,
+                users=["alice@corp.com"],
+                groups=["admins"],
+                servers=[_server("api", ["*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input(user_id="alice@corp.com", groups=["developers"]))
+        assert result.effect == PolicyEffect.ALLOW
+
+    def test_no_match_when_user_and_groups_differ(self):
+        policy = _policy(
+            _rule(
+                "r1",
+                PolicyEffect.ALLOW,
+                users=["alice@corp.com"],
+                groups=["admins"],
+                servers=[_server("api", ["*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input(user_id="bob@corp.com", groups=["developers"]))
+        assert result.effect == PolicyEffect.DENY
+
+
+# ---------------------------------------------------------------------------
+# Server name matching
+# ---------------------------------------------------------------------------
+
+
+class TestServerNameMatching:
+    def test_exact_server_match(self):
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(mcp_server="api")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(mcp_server="other")).effect == PolicyEffect.DENY
+
+    def test_wildcard_server(self):
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("*", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(mcp_server="anything")).effect == PolicyEffect.ALLOW
+
+    def test_prefix_server_wildcard(self):
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("internal-*", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(mcp_server="internal-infra")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(mcp_server="internal-tools")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(mcp_server="external-api")).effect == PolicyEffect.DENY
+
+    def test_multiple_server_entries(self):
+        """A rule with multiple server entries matches if any one matches."""
+        policy = _policy(
+            _rule(
+                "r1",
+                PolicyEffect.ALLOW,
+                servers=[
+                    _server("api", ["read_file"]),
+                    _server("local", ["list_files"]),
+                ],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        assert (
+            engine.evaluate(_input(mcp_server="api", tool="read_file")).effect == PolicyEffect.ALLOW
+        )
+        assert (
+            engine.evaluate(_input(mcp_server="local", tool="list_files")).effect
+            == PolicyEffect.ALLOW
+        )
+        assert (
+            engine.evaluate(_input(mcp_server="other", tool="read_file")).effect
+            == PolicyEffect.DENY
+        )
+
+    def test_no_servers_means_no_match(self):
+        """A rule with empty mcp_servers list never matches."""
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[]),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input())
+        assert result.effect == PolicyEffect.DENY
+
+
+# ---------------------------------------------------------------------------
+# Tool matching
+# ---------------------------------------------------------------------------
+
+
+class TestToolMatching:
+    def test_exact_tool_match(self):
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["read_file"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(tool="read_file")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(tool="write_file")).effect == PolicyEffect.DENY
+
+    def test_wildcard_tool(self):
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(tool="anything")).effect == PolicyEffect.ALLOW
+
+    def test_prefix_tool_wildcard(self):
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["read_*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(tool="read_file")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(tool="read_config")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(tool="write_file")).effect == PolicyEffect.DENY
+
+    def test_suffix_tool_wildcard(self):
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["*_file"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(tool="read_file")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(tool="write_file")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(tool="list_configs")).effect == PolicyEffect.DENY
+
+    def test_empty_tools_matches_all(self):
+        """An empty tools list on a server entry matches any tool."""
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api")]),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(tool="anything")).effect == PolicyEffect.ALLOW
+
+    def test_multiple_tool_patterns(self):
+        policy = _policy(
+            _rule(
+                "r1",
+                PolicyEffect.ALLOW,
+                servers=[_server("api", ["read_file", "list_*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        assert engine.evaluate(_input(tool="read_file")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(tool="list_repos")).effect == PolicyEffect.ALLOW
+        assert engine.evaluate(_input(tool="delete_file")).effect == PolicyEffect.DENY
+
+
+# ---------------------------------------------------------------------------
+# Deny overrides allow
+# ---------------------------------------------------------------------------
+
+
+class TestDenyOverridesAllow:
+    def test_deny_after_allow(self):
+        """A deny rule overrides an earlier allow rule."""
+        policy = _policy(
+            _rule("allow-all", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+            _rule("deny-delete", PolicyEffect.DENY, servers=[_server("api", ["delete_*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        # Allowed tool → allow (deny rule doesn't match this tool)
+        result = engine.evaluate(_input(tool="read_file"))
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id == "allow-all"
+
+        # Denied tool → deny (deny rule overrides the allow)
+        result = engine.evaluate(_input(tool="delete_record"))
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id == "deny-delete"
+
+    def test_deny_before_allow(self):
+        """A deny rule placed before allow still denies."""
+        policy = _policy(
+            _rule("deny-delete", PolicyEffect.DENY, servers=[_server("api", ["delete_*"])]),
+            _rule("allow-all", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input(tool="delete_record"))
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id == "deny-delete"
+
+    def test_deny_wins_even_with_multiple_allows(self):
+        policy = _policy(
+            _rule("allow-1", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+            _rule("allow-2", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+            _rule("deny-1", PolicyEffect.DENY, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input())
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id == "deny-1"
+
+
+# ---------------------------------------------------------------------------
+# First-match-wins (among allows)
+# ---------------------------------------------------------------------------
+
+
+class TestFirstMatchWins:
+    def test_first_allow_is_used(self):
+        """When multiple allow rules match, the first one determines the policy_id."""
+        policy = _policy(
+            _rule("first", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+            _rule("second", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input())
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id == "first"
+
+    def test_first_deny_is_used(self):
+        """When multiple deny rules match, the first one determines the policy_id."""
+        policy = _policy(
+            _rule("first-deny", PolicyEffect.DENY, servers=[_server("api", ["*"])]),
+            _rule("second-deny", PolicyEffect.DENY, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input())
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id == "first-deny"
+
+
+# ---------------------------------------------------------------------------
+# Default behavior
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultBehavior:
+    def test_default_deny(self):
+        """No matching rules + default deny → deny."""
+        policy = _policy(
+            _rule(
+                "r1", PolicyEffect.ALLOW, users=["other@corp.com"], servers=[_server("api", ["*"])]
+            ),
+            default=PolicyEffect.DENY,
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input(user_id="unmatched@corp.com"))
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id is None
+        assert result.reason == "No matching policy; default is deny"
+
+    def test_default_allow(self):
+        """No matching rules + default allow → allow."""
+        policy = _policy(
+            _rule(
+                "r1", PolicyEffect.DENY, users=["blocked@corp.com"], servers=[_server("api", ["*"])]
+            ),
+            default=PolicyEffect.ALLOW,
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input(user_id="unmatched@corp.com"))
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id is None
+        assert result.reason is None
+
+    def test_no_rules_uses_default(self):
+        """An empty policy uses the default."""
+        policy = _policy(default=PolicyEffect.DENY)
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input())
+        assert result.effect == PolicyEffect.DENY
+        assert result.reason == "No matching policy; default is deny"
+
+
+# ---------------------------------------------------------------------------
+# Error handling (fail closed)
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosed:
+    def test_evaluation_error_produces_deny(self):
+        """Any exception during evaluation results in deny."""
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        with patch.object(
+            PolicyEngine,
+            "_evaluate_rules",
+            side_effect=RuntimeError("unexpected error"),
+        ):
+            result = engine.evaluate(_input())
+
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id is None
+        assert "Evaluation error" in result.reason
+        assert "unexpected error" in result.reason
+
+    def test_broken_rule_matching_produces_deny(self):
+        """If rule matching raises an unexpected error, fail closed."""
+        policy = _policy(
+            _rule("r1", PolicyEffect.ALLOW, servers=[_server("api", ["*"])]),
+        )
+        engine = PolicyEngine(policy)
+
+        with patch.object(
+            PolicyEngine,
+            "_rule_matches",
+            side_effect=TypeError("unexpected"),
+        ):
+            result = engine.evaluate(_input())
+
+        assert result.effect == PolicyEffect.DENY
+        assert "Evaluation error" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Complex / integration scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestComplexScenarios:
+    def test_full_policy_scenario(self):
+        """Mimics the policy schema example from docs."""
+        policy = _policy(
+            # Platform ops can use internal tools
+            _rule(
+                "allow-platform-ops",
+                PolicyEffect.ALLOW,
+                groups=["platform-ops", "sre"],
+                servers=[
+                    _server("internal-infra-mcp", ["read_logs", "query_metrics", "restart_service"])
+                ],
+            ),
+            # Developers get read-only external access
+            _rule(
+                "allow-dev-readonly",
+                PolicyEffect.ALLOW,
+                groups=["developers"],
+                servers=[
+                    _server("github-mcp", ["list_repos", "read_issues", "read_pull_requests"])
+                ],
+            ),
+            # Deny destructive tools on all servers for everyone
+            _rule(
+                "deny-destructive",
+                PolicyEffect.DENY,
+                groups=["*"],
+                servers=[_server("*", ["delete_*", "write_*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        # SRE reading logs → allowed
+        result = engine.evaluate(
+            _input(
+                user_id="sre1", groups=["sre"], mcp_server="internal-infra-mcp", tool="read_logs"
+            )
+        )
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id == "allow-platform-ops"
+
+        # Developer reading issues → allowed
+        result = engine.evaluate(
+            _input(
+                user_id="dev1", groups=["developers"], mcp_server="github-mcp", tool="read_issues"
+            )
+        )
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id == "allow-dev-readonly"
+
+        # Developer trying to delete → denied (deny-destructive overrides)
+        result = engine.evaluate(
+            _input(
+                user_id="dev1", groups=["developers"], mcp_server="github-mcp", tool="delete_repo"
+            )
+        )
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id == "deny-destructive"
+
+        # SRE trying to write → denied (deny-destructive overrides)
+        result = engine.evaluate(
+            _input(
+                user_id="sre1", groups=["sre"], mcp_server="internal-infra-mcp", tool="write_config"
+            )
+        )
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id == "deny-destructive"
+
+        # Unknown user, unmatched server → default deny
+        result = engine.evaluate(
+            _input(user_id="visitor", groups=[], mcp_server="unknown-server", tool="some_tool")
+        )
+        assert result.effect == PolicyEffect.DENY
+        assert result.policy_id is None
+
+    def test_user_in_multiple_groups(self):
+        """User matching multiple group-based rules — first allow wins, deny overrides."""
+        policy = _policy(
+            _rule(
+                "allow-devs",
+                PolicyEffect.ALLOW,
+                groups=["developers"],
+                servers=[_server("api", ["read_*"])],
+            ),
+            _rule(
+                "allow-ops",
+                PolicyEffect.ALLOW,
+                groups=["ops"],
+                servers=[_server("api", ["deploy_*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        # User in both groups — first matching allow wins
+        result = engine.evaluate(
+            _input(groups=["developers", "ops"], mcp_server="api", tool="read_config")
+        )
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id == "allow-devs"
+
+        # Same user, different tool — second rule matches
+        result = engine.evaluate(
+            _input(groups=["developers", "ops"], mcp_server="api", tool="deploy_app")
+        )
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.policy_id == "allow-ops"
+
+    def test_server_specific_deny_does_not_affect_other_servers(self):
+        """A deny on one server doesn't block access to another."""
+        policy = _policy(
+            _rule(
+                "deny-external",
+                PolicyEffect.DENY,
+                servers=[_server("external-api", ["*"])],
+            ),
+            _rule(
+                "allow-internal",
+                PolicyEffect.ALLOW,
+                servers=[_server("internal-api", ["*"])],
+            ),
+        )
+        engine = PolicyEngine(policy)
+
+        result = engine.evaluate(_input(mcp_server="internal-api"))
+        assert result.effect == PolicyEffect.ALLOW
+
+        result = engine.evaluate(_input(mcp_server="external-api"))
+        assert result.effect == PolicyEffect.DENY
+
+
+# ---------------------------------------------------------------------------
+# Data class tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataClasses:
+    def test_policy_input_defaults(self):
+        pi = PolicyInput(user_id="alice")
+        assert pi.user_id == "alice"
+        assert pi.groups == []
+        assert pi.mcp_server == ""
+        assert pi.tool == ""
+
+    def test_policy_input_frozen(self):
+        pi = PolicyInput(user_id="alice")
+        with pytest.raises(AttributeError):
+            pi.user_id = "bob"
+
+    def test_evaluation_result_defaults(self):
+        r = EvaluationResult(effect=PolicyEffect.ALLOW)
+        assert r.effect == PolicyEffect.ALLOW
+        assert r.policy_id is None
+        assert r.reason is None
+
+    def test_evaluation_result_frozen(self):
+        r = EvaluationResult(effect=PolicyEffect.DENY, policy_id="r1", reason="blocked")
+        with pytest.raises(AttributeError):
+            r.effect = PolicyEffect.ALLOW


### PR DESCRIPTION
## Summary

Implement the core policy evaluation engine that takes a user identity, MCP server name, and tool name as input and produces an allow/deny decision based on the loaded policy rules.

## Changes

- **New `PolicyEngine` class** (`src/mcp_zero/governance/engine.py`) with `evaluate()` method implementing:
  - Top-down policy evaluation (file order matters)
  - Deny-overrides-allow semantics (explicit deny always wins)
  - First-match-wins within same effect type
  - Fail-closed error handling (exceptions → deny)
- **New `PolicyInput` dataclass** — evaluation input (user_id, groups, mcp_server, tool)
- **New `EvaluationResult` dataclass** — evaluation output (effect, policy_id, reason)
- **Wildcard matching** for server names and tool names (`*`, `prefix*`, `*suffix`, exact)
- **Subject matching** — user ID direct match, group intersection, `*` wildcard group, empty subjects = match everyone
- **Updated `_validate_cross_references`** in `loader.py` to skip wildcard server name patterns
- **Updated `__init__.py`** exports for the governance package
- **39 comprehensive tests** covering all acceptance criteria

## Motivation

This is the core governance decision engine required by Epic 3 (Governance Engine). It enables the gateway to enforce allow/deny policies at the server/tool/user level before proxying MCP requests to upstream servers.

## Testing

```bash
scripts\test.bat -v tests/governance/test_engine.py   # 39 tests
scripts\test.bat                                       # full suite (457 tests)
scripts\lint.bat                                       # all checks pass
```

Test coverage includes:
- Pattern matching (wildcard, prefix, suffix, exact, hyphens)
- Subject matching (user ID, groups, intersection, wildcard `*`, empty)
- Server name matching (exact, wildcard, prefix, multiple entries)
- Tool matching (exact, wildcard, prefix, suffix, empty list, multiple patterns)
- Deny overrides allow (deny before/after allow, multiple allows + deny)
- First-match-wins ordering
- Default behavior (default-deny, default-allow, no rules)
- Fail-closed error handling
- Complex integration scenarios mirroring the policy schema example from docs
- Dataclass immutability

## Related Issues

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)