### PR TITLE
feat: add GovernanceHook for allow/deny policy enforcement

### DIFF
--- a/src/mcp_zero/governance/__init__.py
+++ b/src/mcp_zero/governance/__init__.py
@@ -23,6 +23,7 @@ from mcp_zero.governance.errors import (
     PolicyReferenceError,
     PolicyValidationError,
 )
+from mcp_zero.governance.hook import GovernanceHook
 from mcp_zero.governance.loader import (
     convert_to_identity_config,
     convert_to_server_configs,
@@ -31,6 +32,7 @@ from mcp_zero.governance.loader import (
 
 __all__ = [
     "EvaluationResult",
+    "GovernanceHook",
     "GovernanceError",
     "IdentityProviderConfig",
     "LoggingConfig",

--- a/src/mcp_zero/governance/hook.py
+++ b/src/mcp_zero/governance/hook.py
@@ -1,0 +1,79 @@
+"""Governance lifecycle hook — bridges PolicyEngine to the request pipeline."""
+
+from __future__ import annotations
+
+import logging
+
+from mcp_zero.context import HookContext, PolicyDecision
+from mcp_zero.governance.config import PolicyEffect
+from mcp_zero.governance.engine import EvaluationResult, PolicyEngine, PolicyInput
+from mcp_zero.pipeline.errors import ShortCircuitError
+from mcp_zero.pipeline.hooks import LifecycleHook
+
+logger = logging.getLogger(__name__)
+
+
+class GovernanceHook(LifecycleHook):
+    """Evaluates governance policies at POST_VALIDATION.
+
+    Runs after IdentityHook has resolved user identity.  Builds a
+    :class:`PolicyInput` from the hook context and delegates to the
+    :class:`PolicyEngine` for an allow/deny decision.
+
+    Fail-closed: if no identity is present the request is denied without
+    consulting the engine.
+    """
+
+    def __init__(self, engine: PolicyEngine) -> None:
+        self._engine = engine
+
+    async def on_post_validation(self, ctx: HookContext) -> HookContext:
+        identity = ctx.request.identity
+        correlation_id = ctx.request.correlation_id
+
+        # Fail-closed: no identity means we cannot evaluate policy
+        if identity is None:
+            logger.warning(
+                "No authenticated identity — denying request "
+                "(correlation_id=%s, server=%s, tool=%s)",
+                correlation_id,
+                ctx.server_name,
+                ctx.tool_name,
+            )
+            raise ShortCircuitError("No authenticated identity", deny=True)
+
+        policy_input = PolicyInput(
+            user_id=identity.user_id,
+            groups=list(identity.groups),
+            mcp_server=ctx.server_name,
+            tool=ctx.tool_name,
+        )
+
+        result: EvaluationResult = self._engine.evaluate(policy_input)
+
+        if result.effect == PolicyEffect.ALLOW:
+            logger.info(
+                "Policy ALLOW: user=%s server=%s tool=%s policy_id=%s correlation_id=%s",
+                identity.user_id,
+                ctx.server_name,
+                ctx.tool_name,
+                result.policy_id or "",
+                correlation_id,
+            )
+            return ctx.evolve(
+                policy_decision=PolicyDecision.ALLOW,
+                policy_rule_id=result.policy_id or "",
+            )
+
+        # DENY
+        reason = result.reason or "Denied by policy"
+        logger.warning(
+            "Policy DENY: user=%s server=%s tool=%s policy_id=%s correlation_id=%s reason=%s",
+            identity.user_id,
+            ctx.server_name,
+            ctx.tool_name,
+            result.policy_id or "",
+            correlation_id,
+            reason,
+        )
+        raise ShortCircuitError(reason, deny=True)

--- a/src/mcp_zero/main.py
+++ b/src/mcp_zero/main.py
@@ -7,6 +7,7 @@ import os
 
 import uvicorn
 
+from mcp_zero.governance import GovernanceHook, PolicyConfig, PolicyEngine
 from mcp_zero.governance.errors import GovernanceError
 from mcp_zero.governance.loader import (
     convert_to_identity_config,
@@ -43,15 +44,18 @@ def _load_server_configs() -> list[ServerConfig]:
     ]
 
 
-def _load_policy_and_configs() -> tuple[list[ServerConfig], IdentityConfig | None]:
-    """Load server configs and identity config from policy file or env vars.
+def _load_policy_and_configs() -> tuple[
+    list[ServerConfig], IdentityConfig | None, PolicyConfig | None
+]:
+    """Load server configs, identity config, and policy config from policy file or env vars.
 
     Reads ``MCP_POLICY_FILE`` env var for the policy file path.
     If not set, falls back to legacy ``MCP_UPSTREAM_URL`` behavior.
 
     Returns:
-        A tuple of (server_configs, identity_config). identity_config is None
-        when no identity section is in the policy or when using legacy env vars.
+        A 3-tuple of (server_configs, identity_config, policy_config).
+        identity_config and policy_config are None when no policy file is
+        configured or when using legacy env vars.
 
     Raises:
         GovernanceError: If the policy file is invalid (fail-fast at startup).
@@ -60,7 +64,7 @@ def _load_policy_and_configs() -> tuple[list[ServerConfig], IdentityConfig | Non
 
     if not policy_file:
         logger.info("MCP_POLICY_FILE not set — using legacy env var configuration")
-        return _load_server_configs(), None
+        return _load_server_configs(), None, None
 
     try:
         policy = load_policy_file(policy_file)
@@ -70,16 +74,20 @@ def _load_policy_and_configs() -> tuple[list[ServerConfig], IdentityConfig | Non
 
     configs = convert_to_server_configs(policy)
     identity_config = convert_to_identity_config(policy)
-    return configs, identity_config
+    return configs, identity_config, policy
 
 
-def _build_identity_pipeline(
+def _build_pipeline(
     identity_config: IdentityConfig | None = None,
+    policy_config: PolicyConfig | None = None,
 ) -> Pipeline | None:
-    """Build a Pipeline with the IdentityHook.
+    """Build a Pipeline with identity and governance hooks.
 
     If *identity_config* is provided (from a policy file), it is used directly.
     Otherwise falls back to ``OKTA_ISSUER`` / ``OKTA_AUDIENCE`` env vars.
+
+    If *policy_config* is provided, a GovernanceHook is registered at priority 50
+    (after IdentityHook at priority 10) to enforce allow/deny policies.
     """
     if identity_config is None:
         issuer = os.environ.get("OKTA_ISSUER", "")
@@ -99,10 +107,17 @@ def _build_identity_pipeline(
 
     jwks_client = JWKSClient(identity_config)
     validator = JWTValidator(identity_config, jwks_client)
-    hook = IdentityHook(validator)
+    identity_hook = IdentityHook(validator)
 
     registry = HookRegistry()
-    registry.register(hook, priority=10)
+    registry.register(identity_hook, priority=10)
+
+    if policy_config is not None:
+        engine = PolicyEngine(policy_config)
+        governance_hook = GovernanceHook(engine)
+        registry.register(governance_hook, priority=50)
+        logger.info("Governance policy enforcement enabled (%d rules)", len(policy_config.policies))
+
     registry.build()
 
     logger.info("Identity validation enabled (issuer=%s)", identity_config.issuer)
@@ -165,12 +180,12 @@ def run() -> None:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    configs, identity_config = _load_policy_and_configs()
+    configs, identity_config, policy_config = _load_policy_and_configs()
     if not configs:
         logger.info("No upstream servers configured — starting in pass-through mode")
 
-    # Build identity pipeline (from policy file or env vars)
-    pipeline = _build_identity_pipeline(identity_config)
+    # Build pipeline with identity + governance hooks
+    pipeline = _build_pipeline(identity_config, policy_config)
 
     # Build OBO auth provider when Okta OBO env vars are set
     auth_provider = _build_obo_provider(configs)

--- a/src/mcp_zero/proxy/proxy_server.py
+++ b/src/mcp_zero/proxy/proxy_server.py
@@ -91,10 +91,18 @@ class ProxyServer:
             result = await self._pipeline.execute(hook_ctx)
             hook_ctx = result.context
             if hook_ctx.policy_decision == PolicyDecision.DENY:
+                correlation_id = hook_ctx.request.correlation_id
+                logger.warning(
+                    "Request denied: %s (correlation_id=%s, server=%s, tool=%s)",
+                    hook_ctx.short_circuit_reason,
+                    correlation_id,
+                    server_name,
+                    tool_name,
+                )
                 return [
                     types.TextContent(
                         type="text",
-                        text=f"Request denied: {hook_ctx.short_circuit_reason}",
+                        text=f"Access denied (correlation_id={correlation_id})",
                     )
                 ]
 

--- a/tests/governance/test_hook.py
+++ b/tests/governance/test_hook.py
@@ -1,0 +1,179 @@
+"""Tests for the GovernanceHook lifecycle hook."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_zero.context import HookContext, PolicyDecision, RequestContext, UserIdentity
+from mcp_zero.governance.config import PolicyEffect
+from mcp_zero.governance.engine import EvaluationResult, PolicyInput
+from mcp_zero.governance.hook import GovernanceHook
+from mcp_zero.pipeline.errors import ShortCircuitError
+
+
+def _make_ctx(
+    *,
+    user_id: str = "user-1",
+    groups: list[str] | None = None,
+    server_name: str = "weather",
+    tool_name: str = "get_forecast",
+    identity: UserIdentity | None = ...,  # type: ignore[assignment]
+) -> HookContext:
+    if identity is ...:
+        identity = UserIdentity(user_id=user_id, groups=groups or [])
+    return HookContext(
+        request=RequestContext(identity=identity),
+        server_name=server_name,
+        tool_name=tool_name,
+    )
+
+
+class TestGovernanceHookAllow:
+    @pytest.mark.asyncio
+    async def test_allow_sets_policy_decision(self):
+        engine = MagicMock()
+        engine.evaluate.return_value = EvaluationResult(
+            effect=PolicyEffect.ALLOW, policy_id="rule-1"
+        )
+
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx()
+        result = await hook.on_post_validation(ctx)
+
+        assert result.policy_decision == PolicyDecision.ALLOW
+        assert result.policy_rule_id == "rule-1"
+
+    @pytest.mark.asyncio
+    async def test_allow_none_policy_id_becomes_empty_string(self):
+        engine = MagicMock()
+        engine.evaluate.return_value = EvaluationResult(effect=PolicyEffect.ALLOW, policy_id=None)
+
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx()
+        result = await hook.on_post_validation(ctx)
+
+        assert result.policy_decision == PolicyDecision.ALLOW
+        assert result.policy_rule_id == ""
+
+    @pytest.mark.asyncio
+    async def test_correct_policy_input_passed_to_engine(self):
+        engine = MagicMock()
+        engine.evaluate.return_value = EvaluationResult(
+            effect=PolicyEffect.ALLOW, policy_id="rule-1"
+        )
+
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx(
+            user_id="alice", groups=["admin", "dev"], server_name="db", tool_name="query"
+        )
+        await hook.on_post_validation(ctx)
+
+        engine.evaluate.assert_called_once()
+        policy_input: PolicyInput = engine.evaluate.call_args[0][0]
+        assert policy_input.user_id == "alice"
+        assert policy_input.groups == ["admin", "dev"]
+        assert policy_input.mcp_server == "db"
+        assert policy_input.tool == "query"
+
+
+class TestGovernanceHookDeny:
+    @pytest.mark.asyncio
+    async def test_deny_raises_short_circuit(self):
+        engine = MagicMock()
+        engine.evaluate.return_value = EvaluationResult(
+            effect=PolicyEffect.DENY, policy_id="deny-rule", reason="Blocked by admin policy"
+        )
+
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx()
+
+        with pytest.raises(ShortCircuitError) as exc_info:
+            await hook.on_post_validation(ctx)
+        assert exc_info.value.deny is True
+        assert "Blocked by admin policy" in exc_info.value.reason
+
+    @pytest.mark.asyncio
+    async def test_deny_fallback_reason_when_none(self):
+        engine = MagicMock()
+        engine.evaluate.return_value = EvaluationResult(
+            effect=PolicyEffect.DENY, policy_id="deny-rule", reason=None
+        )
+
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx()
+
+        with pytest.raises(ShortCircuitError) as exc_info:
+            await hook.on_post_validation(ctx)
+        assert exc_info.value.deny is True
+        assert exc_info.value.reason == "Denied by policy"
+
+    @pytest.mark.asyncio
+    async def test_default_deny_short_circuits(self):
+        """Default-deny (no matching rule) still raises ShortCircuitError."""
+        engine = MagicMock()
+        engine.evaluate.return_value = EvaluationResult(
+            effect=PolicyEffect.DENY,
+            policy_id=None,
+            reason="No matching policy; default is deny",
+        )
+
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx()
+
+        with pytest.raises(ShortCircuitError) as exc_info:
+            await hook.on_post_validation(ctx)
+        assert exc_info.value.deny is True
+
+
+class TestGovernanceHookMissingIdentity:
+    @pytest.mark.asyncio
+    async def test_no_identity_denies(self):
+        engine = MagicMock()
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx(identity=None)
+
+        with pytest.raises(ShortCircuitError) as exc_info:
+            await hook.on_post_validation(ctx)
+        assert exc_info.value.deny is True
+        assert "No authenticated identity" in exc_info.value.reason
+
+    @pytest.mark.asyncio
+    async def test_no_identity_skips_engine(self):
+        engine = MagicMock()
+        hook = GovernanceHook(engine)
+        ctx = _make_ctx(identity=None)
+
+        with pytest.raises(ShortCircuitError):
+            await hook.on_post_validation(ctx)
+
+        engine.evaluate.assert_not_called()
+
+
+class TestGovernanceHookProperties:
+    def test_hook_name(self):
+        engine = MagicMock()
+        hook = GovernanceHook(engine)
+        assert hook.name == "GovernanceHook"
+
+    @pytest.mark.asyncio
+    async def test_correlation_id_preserved(self):
+        engine = MagicMock()
+        engine.evaluate.return_value = EvaluationResult(
+            effect=PolicyEffect.ALLOW, policy_id="rule-1"
+        )
+
+        hook = GovernanceHook(engine)
+        original_request = RequestContext(
+            identity=UserIdentity(user_id="user-1"),
+        )
+        ctx = HookContext(
+            request=original_request,
+            server_name="weather",
+            tool_name="get_forecast",
+        )
+        result = await hook.on_post_validation(ctx)
+
+        assert result.request.correlation_id == original_request.correlation_id
+        assert result.request.trace_id == original_request.trace_id

--- a/tests/proxy/test_proxy_server.py
+++ b/tests/proxy/test_proxy_server.py
@@ -214,7 +214,9 @@ class TestProxyServerWithPipeline:
         mgr = ServerManager(make_configs())
 
         mock_pipeline = AsyncMock(spec=Pipeline)
+        deny_request = RequestContext()
         deny_ctx = HookContext(
+            request=deny_request,
             policy_decision=PolicyDecision.DENY,
             short_circuit_reason="blocked by policy",
         )
@@ -226,8 +228,31 @@ class TestProxyServerWithPipeline:
         result = await proxy._call_tool("weather__get_weather", {})
 
         assert len(result) == 1
-        assert "denied" in result[0].text.lower()
-        assert "blocked by policy" in result[0].text
+        assert "Access denied" in result[0].text
+        assert deny_request.correlation_id in result[0].text
+        # Policy internals must NOT leak to the client
+        assert "blocked by policy" not in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_deny_response_includes_correlation_id(self):
+        mgr = ServerManager(make_configs())
+
+        mock_pipeline = AsyncMock(spec=Pipeline)
+        deny_request = RequestContext()
+        deny_ctx = HookContext(
+            request=deny_request,
+            policy_decision=PolicyDecision.DENY,
+            short_circuit_reason="internal reason",
+        )
+        mock_pipeline.execute = AsyncMock(
+            return_value=PipelineResult(context=deny_ctx, success=False)
+        )
+
+        proxy = ProxyServer(mgr, pipeline=mock_pipeline)
+        result = await proxy._call_tool("weather__get_weather", {})
+
+        expected = f"Access denied (correlation_id={deny_request.correlation_id})"
+        assert result[0].text == expected
 
     @pytest.mark.asyncio
     async def test_pipeline_runs_post_hooks(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ import yaml
 from mcp_zero.governance.errors import PolicyFileError
 from mcp_zero.identity.config import IdentityConfig
 from mcp_zero.main import (
-    _build_identity_pipeline,
+    _build_pipeline,
     _load_policy_and_configs,
     _load_server_configs,
     run,
@@ -34,17 +34,19 @@ class TestLoadPolicyAndConfigs:
     def test_no_policy_file_falls_back_to_legacy(self, monkeypatch):
         monkeypatch.delenv("MCP_POLICY_FILE", raising=False)
         monkeypatch.setenv("MCP_UPSTREAM_URL", "http://upstream:9090")
-        configs, identity = _load_policy_and_configs()
+        configs, identity, policy_config = _load_policy_and_configs()
         assert len(configs) == 1
         assert configs[0].name == "default"
         assert identity is None
+        assert policy_config is None
 
     def test_no_policy_file_no_upstream(self, monkeypatch):
         monkeypatch.delenv("MCP_POLICY_FILE", raising=False)
         monkeypatch.delenv("MCP_UPSTREAM_URL", raising=False)
-        configs, identity = _load_policy_and_configs()
+        configs, identity, policy_config = _load_policy_and_configs()
         assert configs == []
         assert identity is None
+        assert policy_config is None
 
     def test_policy_file_loads_configs(self, monkeypatch, tmp_path):
         policy = {
@@ -59,10 +61,11 @@ class TestLoadPolicyAndConfigs:
         path.write_text(yaml.dump(policy))
         monkeypatch.setenv("MCP_POLICY_FILE", str(path))
 
-        configs, identity = _load_policy_and_configs()
+        configs, identity, policy_config = _load_policy_and_configs()
         assert len(configs) == 1
         assert configs[0].name == "api"
         assert identity is None
+        assert policy_config is not None
 
     def test_policy_file_loads_identity(self, monkeypatch, tmp_path):
         policy = {
@@ -80,11 +83,12 @@ class TestLoadPolicyAndConfigs:
         path.write_text(yaml.dump(policy))
         monkeypatch.setenv("MCP_POLICY_FILE", str(path))
 
-        configs, identity = _load_policy_and_configs()
+        configs, identity, policy_config = _load_policy_and_configs()
         assert configs == []
         assert isinstance(identity, IdentityConfig)
         assert identity.issuer == "https://example.okta.com"
         assert identity.audience == "my-app"
+        assert policy_config is not None
 
     def test_invalid_policy_file_raises(self, monkeypatch, tmp_path):
         path = tmp_path / "bad.yaml"
@@ -103,22 +107,22 @@ class TestBuildIdentityPipeline:
     def test_no_issuer_returns_none(self, monkeypatch):
         monkeypatch.delenv("OKTA_ISSUER", raising=False)
         monkeypatch.delenv("OKTA_AUDIENCE", raising=False)
-        assert _build_identity_pipeline() is None
+        assert _build_pipeline() is None
 
     def test_issuer_without_audience_returns_none(self, monkeypatch):
         monkeypatch.setenv("OKTA_ISSUER", "https://okta.example.com")
         monkeypatch.delenv("OKTA_AUDIENCE", raising=False)
-        assert _build_identity_pipeline() is None
+        assert _build_pipeline() is None
 
     def test_with_issuer_and_audience_returns_pipeline(self, monkeypatch):
         monkeypatch.setenv("OKTA_ISSUER", "https://okta.example.com")
         monkeypatch.setenv("OKTA_AUDIENCE", "my-app")
-        result = _build_identity_pipeline()
+        result = _build_pipeline()
         assert isinstance(result, Pipeline)
 
     def test_with_identity_config_returns_pipeline(self):
         config = IdentityConfig(issuer="https://okta.example.com", audience="my-app")
-        result = _build_identity_pipeline(identity_config=config)
+        result = _build_pipeline(identity_config=config)
         assert isinstance(result, Pipeline)
 
     def test_identity_config_skips_env_vars(self, monkeypatch):
@@ -126,7 +130,7 @@ class TestBuildIdentityPipeline:
         monkeypatch.delenv("OKTA_ISSUER", raising=False)
         monkeypatch.delenv("OKTA_AUDIENCE", raising=False)
         config = IdentityConfig(issuer="https://okta.example.com", audience="my-app")
-        result = _build_identity_pipeline(identity_config=config)
+        result = _build_pipeline(identity_config=config)
         assert isinstance(result, Pipeline)
 
 


### PR DESCRIPTION
## Summary

- Wire the `PolicyEngine` into the request lifecycle pipeline via a new `GovernanceHook`
- Sanitize deny responses in `ProxyServer` to prevent leaking policy internals to clients
- Add comprehensive tests for governance enforcement and sanitized responses

## Changes

- **`src/mcp_zero/governance/hook.py`** (new): `GovernanceHook` lifecycle hook that runs at `POST_VALIDATION` to evaluate allow/deny policies via `PolicyEngine`. Fail-closed when no identity is present. Structured audit logging for both allow and deny decisions.
- **`src/mcp_zero/governance/__init__.py`**: Export `GovernanceHook` in public API.
- **`src/mcp_zero/proxy/proxy_server.py`**: Replace `"Request denied: {reason}"` with `"Access denied (correlation_id=...)"` — generic client-safe message. Full reason logged server-side.
- **`src/mcp_zero/main.py`**: Rename `_build_identity_pipeline` → `_build_pipeline`, accept `policy_config`, register `GovernanceHook` at priority 50 (after `IdentityHook` at 10). Return `PolicyConfig` from `_load_policy_and_configs` as a 3-tuple.
- **`tests/governance/test_hook.py`** (new): 10 tests covering allow, deny, missing identity, fallback reasons, hook properties, and correlation ID preservation.
- **`tests/proxy/test_proxy_server.py`**: Updated deny tests to assert sanitized response format and verify policy internals are not leaked.
- **`tests/test_main.py`**: Updated for renamed function and 3-tuple return value.

## Motivation

The `PolicyEngine` and policy loader existed but were not wired into the request lifecycle — policies were loaded and validated at startup but never enforced (issue #18). This change closes the gap, enabling default-deny governance for enterprise MCP traffic.

## Testing

```bash
scripts\test.bat -v    # 468 tests pass
scripts\lint.bat       # clean
scripts\format.bat     # clean
```

## Related Issues

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)