### PR TITLE
feat: correlation & trace IDs for end-to-end request tracing

### DIFF
--- a/src/mcp_zero/audit/event.py
+++ b/src/mcp_zero/audit/event.py
@@ -56,7 +56,7 @@ class AuditEvent:
 
     event_type: AuditEventType
     correlation_id: str = ""
-    trace_id: str = ""
+    trace_id: str | None = None
     user_id: str = ""
     user_groups: list[str] = field(default_factory=list)
     server_name: str = ""

--- a/src/mcp_zero/context.py
+++ b/src/mcp_zero/context.py
@@ -22,24 +22,24 @@ class UserIdentity:
 class RequestContext:
     """Per-request context carrying correlation ID and user identity.
 
-    Each request gets a unique ``correlation_id``.  A ``trace_id`` groups
-    parent-child calls together — it defaults to the ``correlation_id`` of the
-    root request and is inherited by child contexts.
+    Each request gets a unique ``correlation_id``.  A ``trace_id`` links a
+    child request back to its parent — it is ``None`` for top-level requests
+    and set to the parent's ``correlation_id`` for child contexts.
     """
 
     correlation_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    trace_id: str = ""
+    trace_id: str | None = None
     identity: UserIdentity | None = None
     raw_token: str | None = None
 
-    def __post_init__(self) -> None:
-        if not self.trace_id:
-            object.__setattr__(self, "trace_id", self.correlation_id)
-
     def child_context(self) -> RequestContext:
-        """Create a child context with a new correlation ID but the same trace."""
+        """Create a child context with a new correlation ID.
+
+        The child's ``trace_id`` is set to this context's ``correlation_id``,
+        linking the child back to its parent request.
+        """
         return RequestContext(
-            trace_id=self.trace_id,
+            trace_id=self.correlation_id,
             identity=self.identity,
             raw_token=self.raw_token,
         )

--- a/src/mcp_zero/proxy/proxy_server.py
+++ b/src/mcp_zero/proxy/proxy_server.py
@@ -118,7 +118,8 @@ class ProxyServer:
             return [
                 types.TextContent(
                     type="text",
-                    text=f"Request denied: token exchange failed: {exc}",
+                    text=f"Request denied: token exchange failed "
+                    f"(correlation_id={context.correlation_id}): {exc}",
                 )
             ]
 

--- a/src/mcp_zero/transport/http.py
+++ b/src/mcp_zero/transport/http.py
@@ -35,7 +35,8 @@ class StreamableHTTPTransport(MCPTransport):
             headers: dict[str, str] = {}
             if context:
                 headers["X-Correlation-ID"] = context.correlation_id
-                headers["X-Trace-ID"] = context.trace_id
+                if context.trace_id is not None:
+                    headers["X-Trace-ID"] = context.trace_id
             if auth_token:
                 headers["Authorization"] = f"Bearer {auth_token}"
 

--- a/src/mcp_zero/transport/stdio.py
+++ b/src/mcp_zero/transport/stdio.py
@@ -38,12 +38,12 @@ class StdioTransport(MCPTransport):
             env = dict(self._config.env) if self._config.env else None
             if context and env is not None:
                 env["MCP_CORRELATION_ID"] = context.correlation_id
-                env["MCP_TRACE_ID"] = context.trace_id
+                if context.trace_id is not None:
+                    env["MCP_TRACE_ID"] = context.trace_id
             elif context:
-                env = {
-                    "MCP_CORRELATION_ID": context.correlation_id,
-                    "MCP_TRACE_ID": context.trace_id,
-                }
+                env = {"MCP_CORRELATION_ID": context.correlation_id}
+                if context.trace_id is not None:
+                    env["MCP_TRACE_ID"] = context.trace_id
 
             params = StdioServerParameters(
                 command=self._config.command,  # type: ignore[arg-type]

--- a/tests/audit/test_event.py
+++ b/tests/audit/test_event.py
@@ -90,7 +90,7 @@ class TestAuditEvent:
         event = AuditEvent(event_type=AuditEventType.TOOL_INVOCATION)
         assert event.event_type == AuditEventType.TOOL_INVOCATION
         assert event.correlation_id == ""
-        assert event.trace_id == ""
+        assert event.trace_id is None
         assert event.user_id == ""
         assert event.user_groups == []
         assert event.server_name == ""

--- a/tests/audit/test_hook.py
+++ b/tests/audit/test_hook.py
@@ -71,7 +71,7 @@ class TestAuditHookNormalFlow:
 
         event = hook.events[0]
         assert event.correlation_id == ctx.request.correlation_id
-        assert event.trace_id == ctx.request.trace_id
+        assert event.trace_id is ctx.request.trace_id  # None for top-level
         assert event.user_id == "test-user"
         assert event.server_name == "test-server"
         assert event.tool_name == "test-tool"

--- a/tests/audit/test_json_emitter.py
+++ b/tests/audit/test_json_emitter.py
@@ -113,6 +113,38 @@ class TestJsonEmission:
         assert parsed["response_size_bytes"] == len(json.dumps(resp_payload).encode())
 
 
+class TestJsonTraceIdEmission:
+    """Tests verifying trace_id is null for top-level and set for child contexts."""
+
+    @pytest.mark.asyncio
+    async def test_top_level_emits_trace_id_null(self, caplog):
+        hook = AuditHook()
+        ctx = _make_ctx()  # top-level request, trace_id is None
+
+        with caplog.at_level(logging.INFO, logger="mcp_zero.audit.hook"):
+            await hook.on_pre_audit(ctx)
+
+        parsed = json.loads(caplog.records[0].message)
+        assert parsed["trace_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_child_context_emits_parent_correlation_id_as_trace_id(self, caplog):
+        hook = AuditHook()
+        parent_request = RequestContext(
+            identity=UserIdentity(
+                user_id="test-user", email="test@example.com", groups=["admin", "dev"]
+            ),
+        )
+        child_request = parent_request.child_context()
+        ctx = _make_ctx(request=child_request)
+
+        with caplog.at_level(logging.INFO, logger="mcp_zero.audit.hook"):
+            await hook.on_pre_audit(ctx)
+
+        parsed = json.loads(caplog.records[0].message)
+        assert parsed["trace_id"] == parent_request.correlation_id
+
+
 class TestJsonFieldFiltering:
     """Tests for field filtering via logging.include."""
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -14,9 +14,9 @@ class TestRequestContext:
         ctx = RequestContext()
         assert UUID4_RE.match(ctx.correlation_id)
 
-    def test_trace_id_defaults_to_correlation_id(self):
+    def test_trace_id_defaults_to_none(self):
         ctx = RequestContext()
-        assert ctx.trace_id == ctx.correlation_id
+        assert ctx.trace_id is None
 
     def test_explicit_trace_id_preserved(self):
         ctx = RequestContext(trace_id="my-trace")
@@ -41,10 +41,19 @@ class TestRequestContext:
         assert child.correlation_id != parent.correlation_id
         assert UUID4_RE.match(child.correlation_id)
 
-    def test_child_context_inherits_trace_id(self):
+    def test_child_context_trace_id_is_parent_correlation_id(self):
         parent = RequestContext()
         child = parent.child_context()
-        assert child.trace_id == parent.trace_id
+        assert child.trace_id == parent.correlation_id
+
+    def test_child_of_child_preserves_root_trace_id(self):
+        grandparent = RequestContext()
+        parent = grandparent.child_context()
+        child = parent.child_context()
+        # grandchild's trace_id is its parent's correlation_id (not grandparent's)
+        assert child.trace_id == parent.correlation_id
+        # parent's trace_id is grandparent's correlation_id
+        assert parent.trace_id == grandparent.correlation_id
 
     def test_child_context_inherits_user_identity(self):
         identity = UserIdentity(user_id="u1", email="u@x.com", groups=["admin"])

--- a/tests/transport/test_http.py
+++ b/tests/transport/test_http.py
@@ -140,6 +140,24 @@ class TestStreamableHTTPTransport:
             assert sdk_call_kwargs["http_client"] is mock_httpx_inst
 
     @pytest.mark.asyncio
+    async def test_connect_with_context_no_trace_id_omits_header(self, mock_sdk):
+        cfg = make_http_config()
+        ctx = RequestContext(correlation_id="c-1")  # trace_id defaults to None
+        t = StreamableHTTPTransport(cfg)
+
+        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+            mock_httpx_inst = AsyncMock()
+            mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
+            mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
+            mock_httpx.return_value = mock_httpx_inst
+
+            await t.connect(context=ctx)
+
+            call_kwargs = mock_httpx.call_args[1]
+            assert call_kwargs["headers"]["X-Correlation-ID"] == "c-1"
+            assert "X-Trace-ID" not in call_kwargs["headers"]
+
+    @pytest.mark.asyncio
     async def test_connect_without_context_no_http_client(self, mock_sdk):
         cfg = make_http_config()
         t = StreamableHTTPTransport(cfg)

--- a/tests/transport/test_stdio.py
+++ b/tests/transport/test_stdio.py
@@ -102,6 +102,31 @@ class TestStdioTransport:
         assert call_args.env["MCP_TRACE_ID"] == "t-1"
 
     @pytest.mark.asyncio
+    async def test_connect_no_trace_id_omits_env_var(self, mock_sdk):
+        cfg = make_stdio_config()
+        ctx = RequestContext(correlation_id="c-1")  # trace_id defaults to None
+        t = StdioTransport(cfg)
+
+        await t.connect(context=ctx)
+
+        call_args = mock_sdk["client"].call_args[0][0]
+        assert call_args.env["MCP_CORRELATION_ID"] == "c-1"
+        assert "MCP_TRACE_ID" not in call_args.env
+
+    @pytest.mark.asyncio
+    async def test_connect_no_trace_id_omits_env_var_with_existing_env(self, mock_sdk):
+        cfg = make_stdio_config(env={"EXISTING": "value"})
+        ctx = RequestContext(correlation_id="c-1")  # trace_id defaults to None
+        t = StdioTransport(cfg)
+
+        await t.connect(context=ctx)
+
+        call_args = mock_sdk["client"].call_args[0][0]
+        assert call_args.env["EXISTING"] == "value"
+        assert call_args.env["MCP_CORRELATION_ID"] == "c-1"
+        assert "MCP_TRACE_ID" not in call_args.env
+
+    @pytest.mark.asyncio
     async def test_connect_merges_env_with_correlation(self, mock_sdk):
         cfg = make_stdio_config(env={"EXISTING": "value"})
         ctx = RequestContext(correlation_id="corr-456", trace_id="trace-789")


### PR DESCRIPTION
## Summary

Implements issue #25 — makes `trace_id` semantically correct for parent-child request tracing. Top-level requests now emit `trace_id: null` instead of duplicating the `correlation_id`, and child contexts set `trace_id` to the parent's `correlation_id`.

## Changes

- **`context.py`**: `trace_id` defaults to `None` (was duplicating `correlation_id`); removed `__post_init__`; `child_context()` sets `trace_id = self.correlation_id`
- **`audit/event.py`**: `trace_id` type changed to `str | None = None` (serializes to `null` in JSON)
- **`transport/http.py`**: `X-Trace-ID` header only sent when `trace_id is not None`
- **`transport/stdio.py`**: `MCP_TRACE_ID` env var only set when `trace_id is not None`
- **`proxy/proxy_server.py`**: Token exchange error response now includes `correlation_id`

## Motivation

Issue #25 specifies that top-level requests should have `trace_id: null`, while child requests reference the parent's `correlation_id` as their `trace_id`. The previous implementation set `trace_id = correlation_id` for top-level requests, making it impossible to distinguish top-level from child requests.

## Testing

- All 665 existing tests pass (with updates to reflect new semantics)
- New tests added:
  - `test_trace_id_defaults_to_none` — top-level `trace_id` is `None`
  - `test_child_of_child_preserves_root_trace_id` — grandchild tracing
  - `test_top_level_emits_trace_id_null` — JSON output verification
  - `test_child_context_emits_parent_correlation_id_as_trace_id` — JSON output
  - `test_connect_with_context_no_trace_id_omits_header` — HTTP header
  - `test_connect_no_trace_id_omits_env_var` — stdio env var
  - `test_connect_no_trace_id_omits_env_var_with_existing_env` — stdio with existing env

## Related Issues

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)