### PR TITLE
fix: clean shutdown on Ctrl-C

### DIFF
--- a/src/mcp_zero/main.py
+++ b/src/mcp_zero/main.py
@@ -251,4 +251,9 @@ def run() -> None:
     )
 
     logger.info("Starting mcp-zero gateway on %s:%d", host, port)
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        timeout_graceful_shutdown=5,
+    )

--- a/src/mcp_zero/proxy/app.py
+++ b/src/mcp_zero/proxy/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 from collections.abc import AsyncIterator
 
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
@@ -13,6 +14,8 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from mcp_zero.proxy.middleware import AuthHeaderMiddleware
 from mcp_zero.proxy.proxy_server import ProxyServer
 from mcp_zero.proxy.server_manager import ServerManager
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(
@@ -29,11 +32,16 @@ def create_app(
 
     @contextlib.asynccontextmanager
     async def lifespan(app: Starlette) -> AsyncIterator[None]:
-        async with session_manager.run():
-            try:
+        try:
+            async with session_manager.run():
                 yield
-            finally:
-                await server_manager.disconnect_all()
+        except BaseExceptionGroup:
+            # The session manager's task group may raise an ExceptionGroup
+            # when cancelled during shutdown (e.g. active SSE streams).
+            # This is expected — suppress it for a clean exit.
+            logger.debug("Session manager tasks cancelled during shutdown", exc_info=True)
+        finally:
+            await server_manager.disconnect_all()
 
     async def mcp_asgi(scope: Scope, receive: Receive, send: Send) -> None:
         await session_manager.handle_request(scope, receive, send)

--- a/src/mcp_zero/proxy/server_manager.py
+++ b/src/mcp_zero/proxy/server_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Self
 
 from mcp import ClientSession
@@ -12,6 +13,8 @@ from mcp_zero.proxy.errors import RoutingError
 from mcp_zero.transport.base import MCPTransport
 from mcp_zero.transport.config import ServerConfig
 from mcp_zero.transport.factory import TransportFactory
+
+logger = logging.getLogger(__name__)
 
 
 class ServerManager:
@@ -81,7 +84,10 @@ class ServerManager:
         """Disconnect all transports for clean shutdown."""
         names = list(self._transports.keys())
         for name in names:
-            await self.disconnect(name)
+            try:
+                await self.disconnect(name)
+            except Exception:
+                logger.debug("Error disconnecting server '%s'", name, exc_info=True)
 
     async def __aenter__(self) -> Self:
         return self


### PR DESCRIPTION
## Summary

- Restructure lifespan so `disconnect_all()` runs **outside** the session manager's task group scope, preventing cancel-scope ordering violations
- Catch `BaseExceptionGroup` from cancelled SSE tasks during shutdown (expected noise)
- Make `disconnect_all()` resilient to individual transport failures so one broken server doesn't block cleanup of others
- Add 5-second graceful shutdown timeout to uvicorn to prevent hanging

## Motivation

Ctrl-C produced a wall of `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in` and nested `ExceptionGroup` tracebacks. The root cause was `disconnect_all()` running inside `session_manager.run()`'s anyio task group — when the task group cancelled its scope during shutdown, it corrupted the cancel-scope stack for in-flight disconnect operations.

## Testing

- 729 tests passing
- `ruff check` and `ruff format` clean
- Manual: start gateway with a stdio server configured, connect a client, press Ctrl-C — should exit cleanly with no exception tracebacks

## Related Issues

Follows up on #64 (isolate transport cancel scopes in background tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)