### PR TITLE
feat: add time and combined policy files

### DIFF
--- a/policies/all.yaml
+++ b/policies/all.yaml
@@ -1,0 +1,44 @@
+# Policy: all
+# Combines everything, filesystem, and time MCP servers into one policy.
+# Usage: scripts\run-policy.bat all
+
+version: 1
+default: allow
+
+servers:
+  - name: everything
+    transport: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-everything"
+
+  - name: filesystem
+    transport: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-filesystem"
+      - ".data"
+
+  - name: time
+    transport: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-time"
+
+policies:
+  - id: allow-all
+    description: Allow all tools on all servers
+    effect: allow
+    mcp_servers:
+      - name: everything
+        tools: ["*"]
+      - name: filesystem
+        tools: ["*"]
+      - name: time
+        tools: ["*"]
+
+logging:
+  level: DEBUG

--- a/policies/time.yaml
+++ b/policies/time.yaml
@@ -1,0 +1,25 @@
+# Policy: time
+# MCP "server-time" via stdio — exposes time/timezone tools.
+# Usage: scripts\run-policy.bat time
+
+version: 1
+default: allow
+
+servers:
+  - name: time
+    transport: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-time"
+
+policies:
+  - id: allow-all
+    description: Allow all tools on the time server
+    effect: allow
+    mcp_servers:
+      - name: time
+        tools: ["*"]
+
+logging:
+  level: DEBUG


### PR DESCRIPTION
## Summary

- Add `policies/time.yaml` for the MCP time server (`@modelcontextprotocol/server-time`) via stdio
- Add `policies/all.yaml` that combines everything, filesystem, and time servers into a single policy

## Changes

- `policies/time.yaml` — standalone policy for the time MCP server with allow-all access
- `policies/all.yaml` — combined policy with all three servers (everything, filesystem, time), each with allow-all access and DEBUG logging

## Motivation

Provides a convenient combined policy for running all available MCP servers through the gateway at once, plus a standalone time server policy for isolated use.

## Testing

```bash
# Run individual time policy
scripts\run-policy.bat time

# Run combined policy with all servers
scripts\run-policy.bat all
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)