### PR TITLE
chore: simplify inspector script

### DIFF
--- a/scripts/inspector.bat
+++ b/scripts/inspector.bat
@@ -1,12 +1,8 @@
 @echo off
 REM Launch the MCP Inspector pointed at the running gateway.
 REM Usage: scripts\inspector.bat
-REM        scripts\inspector.bat http://localhost:9000/mcp
 
 cd /d %~dp0..
 
-set URL=%~1
-if "%URL%"=="" set URL=http://localhost:8080/mcp
-
 echo Connecting inspector to %URL%
-npx -y @modelcontextprotocol/inspector --cli %URL%
+npx -y @modelcontextprotocol/inspector


### PR DESCRIPTION
## Summary

Simplify the inspector launch script by removing the custom URL parameter and using the inspector's default connection behavior.

## Changes

- Remove custom URL argument handling from `scripts/inspector.bat`
- Launch inspector without `--cli` flag, using its built-in UI instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)