### PR TITLE
fix: fail-closed startup without security config

### DIFF
--- a/src/mcp_zero/main.py
+++ b/src/mcp_zero/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 
 import uvicorn
 
@@ -233,6 +234,27 @@ def run() -> None:
 
     # Build pipeline with identity + governance hooks
     pipeline = _build_pipeline(identity_config, policy_config)
+
+    # Fail-closed: refuse to start without security controls unless explicitly
+    # opted out via MCP_ALLOW_INSECURE.  This prevents accidentally running
+    # the gateway in production without authn/authz (see issue #52).
+    if pipeline is None:
+        if not _is_insecure_allowed():
+            logger.critical(
+                "REFUSING TO START: No identity provider or policy file configured. "
+                "The gateway would run without authentication, authorization, or "
+                "data protection — this is not safe for production. "
+                "Set MCP_POLICY_FILE to a policy file, or set MCP_ALLOW_INSECURE=true "
+                "to start without security controls (dev/testing only)."
+            )
+            sys.exit(78)  # EX_CONFIG per sysexits.h
+        else:
+            logger.warning(
+                "INSECURE MODE: Starting without authentication or authorization. "
+                "MCP_ALLOW_INSECURE is set — all tool calls will be proxied without "
+                "identity validation, governance checks, or data masking. "
+                "Do NOT use this in production."
+            )
 
     # Build OBO auth provider when Okta OBO env vars are set
     auth_provider = _build_obo_provider(configs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -179,12 +179,26 @@ class TestBuildIdentityPipeline:
 
 
 class TestRun:
-    @patch("mcp_zero.main.uvicorn")
-    def test_starts_uvicorn(self, mock_uvicorn, monkeypatch):
+    def test_refuses_startup_without_config(self, monkeypatch):
+        """Gateway refuses to start without identity/policy config (fail-closed)."""
         monkeypatch.delenv("MCP_UPSTREAM_URL", raising=False)
         monkeypatch.delenv("MCP_POLICY_FILE", raising=False)
         monkeypatch.delenv("OKTA_ISSUER", raising=False)
         monkeypatch.delenv("OKTA_AUDIENCE", raising=False)
+        monkeypatch.delenv("MCP_ALLOW_INSECURE", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            run()
+        assert exc_info.value.code == 78
+
+    @patch("mcp_zero.main.uvicorn")
+    def test_starts_insecure_with_allow_insecure(self, mock_uvicorn, monkeypatch):
+        """Gateway starts without config when MCP_ALLOW_INSECURE is set."""
+        monkeypatch.delenv("MCP_UPSTREAM_URL", raising=False)
+        monkeypatch.delenv("MCP_POLICY_FILE", raising=False)
+        monkeypatch.delenv("OKTA_ISSUER", raising=False)
+        monkeypatch.delenv("OKTA_AUDIENCE", raising=False)
+        monkeypatch.setenv("MCP_ALLOW_INSECURE", "true")
         monkeypatch.setenv("MCP_HOST", "127.0.0.1")
         monkeypatch.setenv("MCP_PORT", "9999")
 


### PR DESCRIPTION
## Summary

The gateway now refuses to start when no identity provider or policy file is configured, preventing accidental deployment without authn/authz controls.

## Changes

- Added fail-closed check in `run()`: if `pipeline is None` and `MCP_ALLOW_INSECURE` is not set, the gateway exits with code 78 (`EX_CONFIG`) and a clear error message
- When `MCP_ALLOW_INSECURE=true` is set, the gateway starts but emits a loud `WARNING` log making the insecure posture unmistakable
- Updated existing test that expected unconfigured startup to succeed
- Added new tests for both the fail-closed path and the explicit insecure opt-in

## Motivation

Without this fix, the gateway silently starts and proxies all tool calls without authentication, authorization, or data masking when no config is provided. This violates least-privilege and enterprise compliance expectations (SOC2/ISO27001 access control controls).

## Testing

```bash
# All 732 tests pass
python -m pytest tests/ -v

# Manual verification:
# 1. Start with no config (should refuse):
python -m mcp_zero
# → CRITICAL log + exit code 78

# 2. Start with explicit insecure mode (should warn):
MCP_ALLOW_INSECURE=true python -m mcp_zero
# → WARNING log, gateway starts

# 3. Start with policy file (should work normally):
MCP_POLICY_FILE=policies/filesystem.yaml python -m mcp_zero
# → Normal startup
```

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)