### PR TITLE
fix: use validated subject identity for OBO cache key

### DIFF
--- a/src/mcp_zero/identity/obo.py
+++ b/src/mcp_zero/identity/obo.py
@@ -57,18 +57,23 @@ class ExchangedToken:
 
 @dataclass(frozen=True)
 class ExchangeCacheKey:
-    """Cache key for token exchange results."""
+    """Cache key for token exchange results.
 
-    subject_jti: str
+    Keyed by validated ``subject_id`` (the ``sub`` claim from the identity
+    token) rather than ``jti`` to avoid cache-key collisions when tokens
+    lack a ``jti`` claim.  See GitHub issue #51.
+    """
+
+    subject_id: str
     target_audience: str
     scopes: tuple[str, ...]
 
     @classmethod
     def from_params(
-        cls, subject_jti: str, target_audience: str, scopes: list[str]
+        cls, subject_id: str, target_audience: str, scopes: list[str]
     ) -> ExchangeCacheKey:
         return cls(
-            subject_jti=subject_jti,
+            subject_id=subject_id,
             target_audience=target_audience,
             scopes=tuple(sorted(scopes)),
         )
@@ -86,17 +91,17 @@ class OBOClient:
     async def exchange_token(
         self,
         subject_token: str,
-        subject_jti: str,
+        subject_id: str,
         target_audience: str,
         scopes: list[str] | None = None,
     ) -> str:
         """Exchange a subject token for a server-scoped access token.
 
         Returns the ``access_token`` string.  Results are cached per
-        (jti, audience, scopes) until they expire.
+        (subject_id, audience, scopes) until they expire.
         """
         scopes = scopes or []
-        key = ExchangeCacheKey.from_params(subject_jti, target_audience, scopes)
+        key = ExchangeCacheKey.from_params(subject_id, target_audience, scopes)
 
         # Fast path: cache hit
         cached = self._cache.get(key)

--- a/src/mcp_zero/proxy/obo_auth.py
+++ b/src/mcp_zero/proxy/obo_auth.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-import jwt as pyjwt
-
 from mcp_zero.context import RequestContext
 from mcp_zero.identity.obo import OBOClient
 from mcp_zero.proxy.auth import AuthProvider
@@ -44,21 +42,13 @@ class OBOAuthProvider(AuthProvider):
             logger.debug("No raw_token on context for server '%s', skipping OBO", server_name)
             return None
 
-        # Extract jti from the raw token (already validated by IdentityHook)
-        jti = self._extract_jti(context.raw_token)
+        if not context.identity:
+            logger.debug("No identity on context for server '%s', skipping OBO", server_name)
+            return None
 
         return await self._obo_client.exchange_token(
             subject_token=context.raw_token,
-            subject_jti=jti,
+            subject_id=context.identity.user_id,
             target_audience=settings.target_audience,
             scopes=settings.scopes,
         )
-
-    @staticmethod
-    def _extract_jti(token: str) -> str:
-        """Extract jti from the raw JWT without verification (already validated)."""
-        try:
-            claims = pyjwt.decode(token, options={"verify_signature": False})
-            return claims.get("jti", "")
-        except pyjwt.PyJWTError:
-            return ""

--- a/tests/identity/test_obo.py
+++ b/tests/identity/test_obo.py
@@ -99,18 +99,23 @@ class TestExchangedToken:
 
 class TestExchangeCacheKey:
     def test_from_params_sorts_scopes(self):
-        key = ExchangeCacheKey.from_params("jti-1", "api://server", ["write", "read"])
+        key = ExchangeCacheKey.from_params("user-1", "api://server", ["write", "read"])
         assert key.scopes == ("read", "write")
 
     def test_equality(self):
-        a = ExchangeCacheKey.from_params("jti-1", "api://server", ["read"])
-        b = ExchangeCacheKey.from_params("jti-1", "api://server", ["read"])
+        a = ExchangeCacheKey.from_params("user-1", "api://server", ["read"])
+        b = ExchangeCacheKey.from_params("user-1", "api://server", ["read"])
         assert a == b
 
     def test_hashable(self):
-        key = ExchangeCacheKey.from_params("jti-1", "api://server", ["read"])
+        key = ExchangeCacheKey.from_params("user-1", "api://server", ["read"])
         d = {key: "value"}
         assert d[key] == "value"
+
+    def test_different_subjects_differ(self):
+        a = ExchangeCacheKey.from_params("user-1", "api://server", ["read"])
+        b = ExchangeCacheKey.from_params("user-2", "api://server", ["read"])
+        assert a != b
 
 
 class TestOBOClient:
@@ -129,7 +134,7 @@ class TestOBOClient:
 
             result = await client.exchange_token(
                 subject_token="token-A",
-                subject_jti="jti-123",
+                subject_id="user-1",
                 target_audience="api://mcp-server",
                 scopes=["read"],
             )
@@ -156,9 +161,9 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             # First call — hits the endpoint
-            await client.exchange_token("token-A", "jti-1", "api://server")
+            await client.exchange_token("token-A", "user-1", "api://server")
             # Second call — should use cache
-            result = await client.exchange_token("token-A", "jti-1", "api://server")
+            result = await client.exchange_token("token-A", "user-1", "api://server")
 
         assert result == "exchanged-token"
         assert mock_http.post.call_count == 1
@@ -169,7 +174,7 @@ class TestOBOClient:
         client = OBOClient(config)
 
         # Pre-populate cache with an expired token
-        key = ExchangeCacheKey.from_params("jti-1", "api://server", [])
+        key = ExchangeCacheKey.from_params("user-1", "api://server", [])
         client._cache[key] = ExchangedToken(
             access_token="old-token",
             token_type="Bearer",
@@ -186,7 +191,7 @@ class TestOBOClient:
             MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            result = await client.exchange_token("token-A", "jti-1", "api://server")
+            result = await client.exchange_token("token-A", "user-1", "api://server")
 
         assert result == "new-token"
 
@@ -209,9 +214,9 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             results = await asyncio.gather(
-                client.exchange_token("token-A", "jti-1", "api://server"),
-                client.exchange_token("token-A", "jti-1", "api://server"),
-                client.exchange_token("token-A", "jti-1", "api://server"),
+                client.exchange_token("token-A", "user-1", "api://server"),
+                client.exchange_token("token-A", "user-1", "api://server"),
+                client.exchange_token("token-A", "user-1", "api://server"),
             )
 
         assert all(r == "exchanged-token" for r in results)
@@ -233,7 +238,7 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(TokenExchangeError, match="HTTP 400"):
-                await client.exchange_token("token-A", "jti-1", "api://server")
+                await client.exchange_token("token-A", "user-1", "api://server")
 
     @pytest.mark.asyncio
     async def test_http_401_raises(self):
@@ -251,7 +256,7 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(TokenExchangeError, match="HTTP 401"):
-                await client.exchange_token("token-A", "jti-1", "api://server")
+                await client.exchange_token("token-A", "user-1", "api://server")
 
     @pytest.mark.asyncio
     async def test_http_500_raises(self):
@@ -269,7 +274,7 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(TokenExchangeError, match="HTTP 500"):
-                await client.exchange_token("token-A", "jti-1", "api://server")
+                await client.exchange_token("token-A", "user-1", "api://server")
 
     @pytest.mark.asyncio
     async def test_missing_access_token_raises(self):
@@ -287,7 +292,7 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(TokenExchangeError, match="missing 'access_token'"):
-                await client.exchange_token("token-A", "jti-1", "api://server")
+                await client.exchange_token("token-A", "user-1", "api://server")
 
     @pytest.mark.asyncio
     async def test_network_error_raises(self):
@@ -301,7 +306,7 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             with pytest.raises(TokenExchangeError, match="request failed"):
-                await client.exchange_token("token-A", "jti-1", "api://server")
+                await client.exchange_token("token-A", "user-1", "api://server")
 
     @pytest.mark.asyncio
     async def test_scopes_included_in_post(self):
@@ -317,7 +322,7 @@ class TestOBOClient:
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
             await client.exchange_token(
-                "token-A", "jti-1", "api://server", scopes=["read", "write"]
+                "token-A", "user-1", "api://server", scopes=["read", "write"]
             )
 
         call_data = mock_http.post.call_args[1]["data"]
@@ -336,7 +341,7 @@ class TestOBOClient:
             MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
             MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            await client.exchange_token("token-A", "jti-1", "api://server")
+            await client.exchange_token("token-A", "user-1", "api://server")
 
         call_data = mock_http.post.call_args[1]["data"]
         assert "scope" not in call_data

--- a/tests/proxy/test_obo_auth.py
+++ b/tests/proxy/test_obo_auth.py
@@ -12,14 +12,17 @@ from mcp_zero.identity.errors import TokenExchangeError
 from mcp_zero.proxy.obo_auth import OBOAuthProvider, ServerOBOSettings
 
 
-def _make_raw_token(jti: str = "jti-123", sub: str = "user-1") -> str:
+def _make_raw_token(sub: str = "user-1") -> str:
     """Create an unsigned JWT for testing (signature not checked by OBOAuthProvider)."""
-    return pyjwt.encode({"jti": jti, "sub": sub}, key="secret", algorithm="HS256")
+    return pyjwt.encode({"sub": sub}, key="secret", algorithm="HS256")
 
 
-def _make_context(raw_token: str | None = None) -> RequestContext:
+def _make_context(
+    raw_token: str | None = None,
+    identity: UserIdentity | None = UserIdentity(user_id="user-1"),
+) -> RequestContext:
     return RequestContext(
-        identity=UserIdentity(user_id="user-1"),
+        identity=identity,
         raw_token=raw_token,
     )
 
@@ -54,7 +57,7 @@ class TestOBOAuthProvider:
         assert result == "token-B"
         obo_client.exchange_token.assert_called_once_with(
             subject_token=raw_token,
-            subject_jti="jti-123",
+            subject_id="user-1",
             target_audience="api://weather",
             scopes=[],
         )
@@ -94,20 +97,41 @@ class TestOBOAuthProvider:
         obo_client.exchange_token.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_missing_jti_uses_empty_string(self):
+    async def test_missing_identity_returns_none(self):
+        obo_client = AsyncMock()
+        settings = {"weather": _make_settings()}
+        provider = OBOAuthProvider(obo_client, settings)
+
+        ctx = _make_context(raw_token=_make_raw_token(), identity=None)
+        result = await provider.get_token("weather", ctx)
+
+        assert result is None
+        obo_client.exchange_token.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_different_users_get_different_cache_keys(self):
+        """Verify that different users produce different subject_id values."""
         obo_client = AsyncMock()
         obo_client.exchange_token = AsyncMock(return_value="token-B")
 
         settings = {"weather": _make_settings()}
         provider = OBOAuthProvider(obo_client, settings)
 
-        # Token without jti claim
-        raw_token = pyjwt.encode({"sub": "user-1"}, key="secret", algorithm="HS256")
-        ctx = _make_context(raw_token=raw_token)
-        await provider.get_token("weather", ctx)
+        ctx_user1 = RequestContext(
+            identity=UserIdentity(user_id="user-1"),
+            raw_token=_make_raw_token(sub="user-1"),
+        )
+        ctx_user2 = RequestContext(
+            identity=UserIdentity(user_id="user-2"),
+            raw_token=_make_raw_token(sub="user-2"),
+        )
 
-        call_kwargs = obo_client.exchange_token.call_args[1]
-        assert call_kwargs["subject_jti"] == ""
+        await provider.get_token("weather", ctx_user1)
+        await provider.get_token("weather", ctx_user2)
+
+        calls = obo_client.exchange_token.call_args_list
+        assert calls[0][1]["subject_id"] == "user-1"
+        assert calls[1][1]["subject_id"] == "user-2"
 
     @pytest.mark.asyncio
     async def test_exchange_error_propagates(self):


### PR DESCRIPTION
## Summary

- **Fixes #51** — OBO cache key collision when JWT `jti` is absent
- Replaces the `jti`-based cache key (`ExchangeCacheKey.subject_jti`) with the validated `user_id` (`sub` claim) from the identity context, eliminating cross-user credential reuse when tokens lack a `jti` claim
- Removes `_extract_jti()` which decoded the JWT without verification and silently returned `""` on missing/error
- Adds a guard in `OBOAuthProvider.get_token()` to skip OBO when identity is missing from the request context

## Test plan

- [x] All 734 existing tests pass
- [x] New test: `test_different_subjects_differ` verifies different users produce distinct cache keys
- [x] New test: `test_missing_identity_returns_none` verifies OBO is skipped when identity is absent
- [x] New test: `test_different_users_get_different_cache_keys` verifies end-to-end that two users pass different `subject_id` values to the OBO client

🤖 Generated with [Claude Code](https://claude.com/claude-code)