### PR TITLE
fix: allow git/gh CLI tools in docs-reconcile workflow

### DIFF
--- a/.github/workflows/docs-reconcile.yml
+++ b/.github/workflows/docs-reconcile.yml
@@ -61,6 +61,7 @@ jobs:
           claude_args: |
             --model ${{ github.event.inputs.model }}
             --max-turns 40
+            --allowedTools "Bash(git:*),Bash(gh pr create:*),Bash(gh pr view:*),Edit,Read,Write,Glob,Grep"
 
       # Optional: surface a quick summary in logs (the action itself posts updates/comments as it runs).
       - name: Done


### PR DESCRIPTION
## Summary

- Fix the docs-reconcile workflow so Claude can actually commit changes and create PRs
- Add `--allowedTools` to `claude_args` permitting `Bash(git:*)`, `Bash(gh pr create:*)`, `Bash(gh pr view:*)`, and file operation tools

## Problem

The [docs-reconcile run](https://github.com/abwaters/mcp-zero/actions/runs/21945513917) completed all 27 turns of doc edits successfully ($1.09 cost), but the `Bash` tool was denied when Claude tried to run `git checkout -b docs/full-reconciliation-2026-02-12`. Without `--allowedTools`, all Bash commands require interactive approval — which doesn't exist in CI. The edits were lost when the runner cleaned up.

## Test plan

- [ ] Re-run the docs-reconcile workflow after merging
- [ ] Verify Claude can create a branch, commit, push, and open a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)