### PR TITLE
feat: Docker Compose with Redis analytics and RedisInsight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,5 @@ The gateway sits between enterprise AI tools and MCP servers:
 - **Transports**: Streamable HTTP and stdio (both enforce full pipeline when configured)
 
 Both HTTP and stdio transports enforce governance, masking, and auditing through the same unified pipeline when configured.
+
+- **Analytics**: Optional Redis-based analytics subsystem (`src/mcp_zero/analytics/`). Enabled by setting `ANALYTICS_REDIS_URL`. See README for all `ANALYTICS_*` env vars. Use `docker compose up` to run Redis + RedisInsight locally.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,10 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies first for layer caching
+# Copy source and install
 COPY pyproject.toml ./
-RUN pip install --no-cache-dir .
-
-# Copy source and install in editable mode
 COPY src/ src/
-RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir .
 
 # Copy policy files
 COPY policies/ policies/

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ The gateway starts on `0.0.0.0:8080` by default (configurable via `MCP_HOST` and
 | `OKTA_TOKEN_ENDPOINT` | Okta token exchange endpoint (for OBO) | _(none)_ |
 | `OKTA_CLIENT_ID` | Gateway client ID (for OBO) | _(none)_ |
 | `OKTA_CLIENT_SECRET` | Gateway client secret (for OBO) | _(none)_ |
+| `ANALYTICS_REDIS_URL` | Redis connection URL (enables analytics when set) | _(none)_ |
+| `ANALYTICS_REDIS_CLUSTER` | Use Redis Cluster client | `false` |
+| `ANALYTICS_REDIS_PASSWORD` | Redis authentication password | _(none)_ |
+| `ANALYTICS_ENVIRONMENT` | Analytics key namespace (e.g. `production`) | `default` |
+| `ANALYTICS_GATEWAY_ID` | Unique gateway instance ID | _(auto-generated)_ |
+| `ANALYTICS_KEY_PREFIX` | Redis key prefix for analytics | `mcpgw` |
+| `ANALYTICS_RETENTION_SECONDS` | TTL for analytics keys in seconds | `3600` |
 
 When `MCP_POLICY_FILE` is set, its identity section takes precedence over `OKTA_*` env vars.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,32 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+  redisinsight:
+    image: redis/redisinsight:latest
+    ports:
+      - "5540:5540"
+    depends_on:
+      - redis
+
+  mcp-zero:
+    build: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+    environment:
+      ANALYTICS_REDIS_URL: redis://redis:6379/0
+      ANALYTICS_ENVIRONMENT: local
+      ANALYTICS_RETENTION_SECONDS: 3600
+      MCP_POLICY_FILE: policies/everything.yaml
+      MCP_ALLOW_INSECURE: "true"
+      LOG_FORMAT: text
+      LOG_LEVEL: DEBUG
+
+volumes:
+  redis-data:

--- a/scripts/docker-compose.bat
+++ b/scripts/docker-compose.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d %~dp0..
+docker compose up --build %*

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+docker compose up --build "$@"


### PR DESCRIPTION
## Summary

- Add `docker-compose.yaml` with three services: Redis (7-alpine), RedisInsight (port 5540), and mcp-zero (built from Dockerfile) wired together with analytics env vars
- Fix Dockerfile build error where `pip install .` ran before `src/` was copied (setuptools needs the source to run `egg_info`)
- Document all `ANALYTICS_*` environment variables in the README env vars table
- Add analytics note to CLAUDE.md architecture section
- Add `scripts/docker-compose.bat` and `scripts/docker-compose.sh` convenience scripts

## Test plan

- [ ] `docker compose up --build` starts all three services without errors
- [ ] Gateway logs show analytics enabled: `redis=redis://redis:6379/0, env=local`
- [ ] MCP Inspector connects to `http://localhost:8080/mcp` via Streamable HTTP
- [ ] RedisInsight at `http://localhost:5540` connects to `redis://default@redis:6379`
- [ ] Tool calls through the gateway produce `mcpgw:*` keys visible in RedisInsight

🤖 Generated with [Claude Code](https://claude.com/claude-code)