### PR TITLE
ci: add dedicated stdio integration test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,22 @@ jobs:
       - name: Test
         run: pytest -v
 
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Stdio integration tests
+        run: pytest tests/integration/test_stdio_integration.py -v
+
   dependabot-auto-merge:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a new `integration` job to the CI workflow that runs stdio integration tests (`tests/integration/test_stdio_integration.py`) in a dedicated parallel job
- Improves CI visibility by separating integration tests from the main test suite
- Uses the same setup pattern as the existing `test` job (ubuntu-latest, Python 3.12)

## Test plan
- [ ] Verify the new `integration` job appears in the GitHub Actions UI
- [ ] Confirm both `test` and `integration` jobs run in parallel and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)