### PR TITLE
fix: harden CI pipeline — unblock Gitleaks false positives, fix auto-merge gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.actor == 'dependabot[bot]' && 'dependabot-ci' || format('ci-{0}', github.run_id) }}
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 # Minimal default token; jobs that need more escalate explicitly below.
 permissions:
@@ -23,6 +24,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
+          cache: 'pip'
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
@@ -45,6 +47,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
+          cache: 'pip'
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
@@ -53,7 +56,7 @@ jobs:
         run: pytest tests/integration/test_stdio_integration.py -v
 
   dependabot-auto-merge:
-    needs: test
+    needs: [test, integration]
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,13 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor != 'dependabot[bot]' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+  description = "Test fixtures with intentional fake PII/secrets for Presidio masking tests"
+  paths = [
+    '''data/pii_samples\.txt''',
+  ]


### PR DESCRIPTION
- Add .gitleaks.toml to allowlist data/pii_samples.txt (intentional test
  fixtures were failing the secret scan on every PR)
- Require both test and integration jobs before dependabot auto-merge
  (previously only waited for unit tests)
- Fix concurrency groups so dependabot PRs each get their own CI slot
  instead of all sharing one (weekly batches were cancelling each other)
- Add pip caching to setup-python steps
- Guard claude.yml against dependabot actor to prevent bot-rejection errors

https://claude.ai/code/session_01AiAaUFSghMmxcJT5fsUxyB