### PR TITLE
ci: test on Python 3.12 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        # 3.12 is the minimum supported version; 3.14 matches the Docker base image
+        python-version: ["3.12", "3.14"]
+
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies
@@ -41,12 +46,16 @@ jobs:
   integration:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.14"]
+
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Run the `test` and `integration` CI jobs on a Python version matrix: 3.12 (minimum supported, per `requires-python`) and 3.14 (the new Docker base image in #168)
- Unblocks #168, whose `python:3.14-slim` bump was otherwise untested by the pipeline

## Notes
The branch ruleset required-check context changes from `test` to `test (3.12)` / `test (3.14)`; the ruleset is being updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)