### PR TITLE
fix(deps): cap mcp sdk below 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "MCP Zero"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp>=1.26.0",
+    "mcp>=1.26.0,<2.0.0",
     "starlette>=0.36",
     "uvicorn>=0.29",
     "PyJWT[crypto]>=2.8",


### PR DESCRIPTION
## Problem

The MCP Python SDK released **2.0.0**. `pyproject.toml` declared `mcp>=1.26.0` with no upper bound, so every fresh CI install resolved to 2.0.0 and the suite collapsed:

```
92 failed, 1036 passed, 10 errors
```

Two breaking changes in 2.0 account for all of it:

- `Server.list_tools` decorator removed — `src/mcp_zero/proxy/proxy_server.py:59`
- Models moved to snake_case: `Tool.inputSchema` → `Tool.input_schema` — `src/mcp_zero/proxy/tool_router.py:38`

Failures span `tests/integration/test_stdio_integration.py` (29), `tests/proxy/` (49), and `tests/test_main.py` (6). The 10 errors are the SSE integration tests failing at fixture startup for the same reason.

This blocked all three open dependabot PRs (#191, #192, #193), none of which changed anything relevant — `dependabot-auto-merge` is skipped while CI is red, so they were stuck.

## Change

One line — cap the resolver at the 1.x line:

```diff
-    "mcp>=1.26.0",
+    "mcp>=1.26.0,<2.0.0",
```

## Follow-up

This is the stopgap, not the fix. Porting the proxy to the 2.x API is a separate change across the ~13 files that touch the affected surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
