### PR TITLE
feat(mcp-v2): migrate gateway to mcp SDK v2

### DIFF
--- a/docs/mcp-v2-migration.md
+++ b/docs/mcp-v2-migration.md
@@ -1,0 +1,206 @@
+# mcp v1 → v2 Migration — Phase 0 Confirmed API Mapping
+
+Status: **Phase 0 complete** (spike + API confirmation). Gates Phases 1–7.
+
+This document records the *verified* v2 API surface, introspected against an
+actually-installed `mcp==2.0.0` (scratch venv, Python 3.12), not the migration
+guide prose — several guide claims proved wrong (noted inline). It supersedes
+the guesswork in the original plan and is the source of truth for the port.
+
+Related: this migration branch is `feat/mcp-v2`, opened to supersede Dependabot
+PR #199 (which merely widened the range to admit v2 and broke CI).
+
+## Installed dependency delta (mcp 2.0.0)
+
+Installing `mcp==2.0.0` pulled: `mcp-types==2.0.0`, **`httpx2==2.10.0`**
+(+`httpcore2`), `starlette==1.6.0`, `pydantic==2.13.x`, `sse-starlette==3.4.x`,
+`opentelemetry-api==1.44.x`, `python-multipart`, `uvicorn`, `truststore`.
+
+- **`httpx2`, not `httpx`.** mcp v2 uses `httpx2` internally and does **not**
+  install plain `httpx`. Confirmed: `import httpx` fails in an mcp-only venv.
+  The gateway's own code (`identity/jwks.py`, `identity/obo.py`) uses `httpx`,
+  so **both must be direct dependencies** going forward (they coexist under
+  different import names).
+- **`starlette==1.6.0`.** Our pin `starlette>=0.36` admits it, but this is a
+  major jump from the 0.x line — smoke-test CORS/middleware/Mount behavior.
+
+## The five confirmed breaking changes
+
+### 1. Types are snake_case now (highest blast radius, mechanical)
+
+`mcp.types` is a permanent **alias** for `mcp_types` (confirmed) — keep existing
+`import mcp.types as types` imports; no import churn needed.
+
+Field renames (verified via `model_fields`):
+
+| v1 (camelCase) | v2 (snake_case) |
+|---|---|
+| `Tool.inputSchema` | `Tool.input_schema` |
+| `CallToolResult.isError` | `CallToolResult.is_error` |
+| `ImageContent.mimeType` | `ImageContent.mime_type` |
+| `CallToolResult.structuredContent` | `CallToolResult.structured_content` |
+
+`model_dump()` now emits **snake_case**; `model_dump(by_alias=True)` emits the
+**camelCase wire format** (`inputSchema`, `isError`, `structuredContent`,
+`_meta`). `model_validate()` accepts snake_case (the field names) — so the
+proxy's internal dump→mask→validate round-trip stays consistent if left in
+snake_case.
+
+New non-optional-looking fields exist on results (`Tool.execution`,
+`Tool.output_schema`, `CallToolResult.result_type`, `ListToolsResult.ttl_ms`,
+`cache_scope`) — all have defaults; our constructors don't need them.
+
+Repo sites to change (from grep):
+- `src/mcp_zero/proxy/tool_router.py:38` — `inputSchema=tool.inputSchema` → `input_schema=tool.input_schema`
+- `src/mcp_zero/proxy/proxy_server.py:252` — `upstream_result.isError` → `.is_error`
+- Tests: `tests/fixtures/echo_server.py` (4×), `echo_server_sse.py` (4×),
+  `tests/proxy/test_tool_router.py` (`inputSchema=` kwargs + `.inputSchema`
+  assert), `test_proxy_server.py:51,57`, `tests/integration/test_stdio_integration.py:240`.
+- Masking payload dicts hardcode `"isError"`:
+  `tests/masking/test_output_masking.py:55,92,112,496,506`,
+  `tests/proxy/test_proxy_server.py:443`. See §Decision below.
+
+### 2. Low-level `Server`: decorators → constructor callbacks (the real work)
+
+**Verified `Server.__init__`** (keyword-only): `Server(name, *, on_list_tools=,
+on_call_tool=, on_read_resource=, lifespan=, ...)`. The `@server.list_tools()`
+and `@server.call_tool()` decorators **no longer exist** (`hasattr` == False).
+
+Handler signatures (verified):
+```python
+on_list_tools: (ctx: ServerRequestContext, params: PaginatedRequestParams | None)
+                 -> Awaitable[ListToolsResult]
+on_call_tool:  (ctx: ServerRequestContext, params: CallToolRequestParams)
+                 -> Awaitable[CallToolResult | InputRequiredResult]
+```
+- Handlers now **return the full result object**, not a bare list.
+  `list[Tool]` → `ListToolsResult(tools=[...])`; `list[content]` →
+  `CallToolResult(content=[...], is_error=...)`.
+- Args arrive as a **params object**, not positional. `CallToolRequestParams`
+  has `.name`, `.arguments` (also `.meta`, `.input_responses`, `.request_state`,
+  `.task`). `ServerRequestContext` exposes `.params`, `.request`, `.request_id`,
+  `.meta`, `.close_sse_stream`.
+- **`Server.run(read, write, initialization_options, raise_exceptions=False)`
+  is UNCHANGED** — it still requires `create_initialization_options()`. (The
+  migration guide's claim that `run()` drops init options is **wrong**.)
+
+**Verified live** in-memory round trip with this exact pattern: `list_tools`
+returned a `Tool` with `input_schema`; `call_tool` returned a `CallToolResult`
+with `.is_error=False` and `.content=[TextContent(text=...)]`. ✅
+
+Affected: `src/mcp_zero/proxy/proxy_server.py:50,58-67` (construction +
+`_register_handlers`), and the two test fixtures' `_build_server()`.
+
+### 3. Client side barely moves (migration guide was wrong here)
+
+All still exist and are importable:
+- `from mcp import ClientSession` — constructor **unchanged**:
+  `ClientSession(read_stream, write_stream, ...)`. `.initialize()`,
+  `.list_tools()`, `.call_tool(name, arguments)` all present.
+  `.list_tools()` → `ListToolsResult`; `.call_tool()` →
+  `CallToolResult | InputRequiredResult | Result`.
+- `from mcp.client.stdio import stdio_client` — yields **2-tuple** `(read,
+  write)`, unchanged. `StdioServerParameters` unchanged (+ new optional `cwd`).
+- `from mcp.client.sse import sse_client` — old kwargs `headers=`,
+  `sse_read_timeout=` still present; added `httpx_client_factory=`, `auth=`.
+- `from mcp.client.streamable_http import streamable_http_client` — **now
+  yields a 2-tuple** `TransportStreams = (read, write)`. The old 3rd element
+  `get_session_id` was removed. **`http_client=` must now be an
+  `httpx2.AsyncClient`** (helper: `create_mcp_http_client(headers, timeout,
+  auth)`).
+
+So the "introduce `Client(...).session(transport)` object" from the plan is
+**optional**, not required. The manual `ClientSession(read, write)` pattern
+survives. Client-side work reduces to:
+- `src/mcp_zero/transport/http.py:84-90` — unpack **2** values not 3
+  (`get_session_id` gone), and build the client with **httpx2**.
+- `session.initialize()` (`transport/{stdio,sse,http}.py`) is fine against
+  real 2025-era upstreams. (It only 404s on the modern in-memory path, which
+  we don't use for upstreams.) Keep it; verify against a live upstream in
+  Phase 3.
+
+Note: `Client` and `client.session` (a **property**, not a method) exist for
+the new unified client, and `Client(server_object)` gives in-memory testing —
+useful for new tests, but not required for the port.
+
+### 4. Server-side ASGI transports survive nearly intact
+
+- `from mcp.server.sse import SseServerTransport` — `SseServerTransport(endpoint,
+  security_settings=None)`, `.connect_sse(scope, receive, send)`,
+  `.handle_post_message(scope, receive, send)` — **all unchanged**.
+- `from mcp.server.streamable_http_manager import StreamableHTTPSessionManager`
+  — `StreamableHTTPSessionManager(app, event_store=None, json_response=False,
+  stateless=False, ...)`, `.run()`, `.handle_request(scope, receive, send)` —
+  **unchanged**. Current call `StreamableHTTPSessionManager(app=mcp_server,
+  stateless=False)` still valid.
+- `from mcp.server.stdio import stdio_server` — still a context manager.
+
+So `src/mcp_zero/proxy/app.py` barely changes. `Server` even grows a convenience
+`.streamable_http_app(...)` and `.session_manager` — optional, not needed since
+we mount manually. **SSE is NOT removed** in v2 → `MCP_SSE_ENABLED` and the SSE
+integration tests are **ported, not retired.**
+
+### 5. Config / env vars
+
+`MCP_*` env vars read by the gateway are **our own** config (`main.py`), not SDK
+vars — **unaffected**. mcp v2 dropping `pydantic-settings`/`MCP_*` does not touch
+us. `StdioServerParameters.env` still carries our `MCP_CORRELATION_ID`/
+`MCP_TRACE_ID` injections unchanged.
+
+## Decision: internal payload dict — snake_case vs by_alias
+
+`proxy_server.py:251-252` dumps upstream content to a dict for the masking
+pipeline, then rebuilds via `model_validate` (`:327-331`). Options:
+
+- **(Recommended) Keep it snake_case.** Change `.isError`→`.is_error`; leave
+  `c.model_dump()` as-is (now snake_case). The dump→mask→validate round-trip is
+  self-consistent, and the object returned to the SDK is re-serialized to the
+  camelCase wire format by the SDK itself. Cost: update masking tests that
+  hardcode `"isError"` → `"is_error"`.
+- Alternative: `model_dump(by_alias=True)` + `"isError"` to preserve the old
+  dict shape and avoid touching those tests — but then `model_validate` must
+  also round-trip camelCase, and we'd be carrying wire format internally for no
+  functional gain.
+
+Chosen: **snake_case internal**, update the ~7 test assertions.
+
+## Revised effort assessment (vs original plan)
+
+| Phase | Original fear | Confirmed reality |
+|---|---|---|
+| 1 Types | wide | **wide but mechanical** — field renames + ~7 test key updates |
+| 2 Server | large | **the main work** — handler signature + return-object change |
+| 3 Client | large rewrite | **small** — httpx2 client + 3→2-tuple unpack; sessions unchanged |
+| 4 ASGI | biggest risk | **minimal** — SSE + session manager APIs unchanged |
+| 5 Tests | large | fixtures rewritten to `on_*` callbacks; field renames |
+| 6 Deps/CI | — | `mcp>=2,<3`, **add `httpx2`**, keep `httpx`, verify starlette 1.6 |
+| 7 Docs | — | update SSE note stays "deprecated but supported"; drop v1 refs |
+
+**Net:** the migration is *smaller and lower-risk* than the pre-spike plan
+assumed. The `Client`/transport rewrite and the "SSE removed" contingency are
+both off the table. Concentrate effort on Phase 2 (server handlers) and Phase 1
+(field renames).
+
+## pyproject deltas (Phase 6 preview)
+
+```toml
+dependencies = [
+    "mcp>=2.0.0,<3.0.0",   # was >=1.26.0,<2.0.0
+    "httpx2>=2.10",        # NEW — for streamable_http_client http_client=
+    "httpx>=0.27",         # KEEP — gateway JWKS/OBO code
+    "starlette>=1.6",      # verify; was >=0.36
+    # uvicorn/pyyaml/presidio/redis/PyJWT unchanged
+]
+```
+
+## Open items to verify during implementation
+
+1. Live upstream `session.initialize()` handshake against a real 2025-era stdio
+   server (Phase 3) — confirm it doesn't 404 like the modern in-memory path.
+2. `starlette==1.6.0` CORS middleware + `Mount` behavior in `proxy/app.py`
+   (Phase 4 smoke test).
+3. New "exceptions in handlers surface as JSON-RPC errors" behavior vs the
+   gateway's fail-closed `ShortCircuitError`/`HookError` path — confirm denials
+   still render as a proper error to the client (Phase 2).
+4. presidio/spacy vs `pydantic==2.13` and `numpy` resolver on Python 3.14 CI.
+```

--- a/docs/mcp-v2-migration.md
+++ b/docs/mcp-v2-migration.md
@@ -1,6 +1,11 @@
 # mcp v1 → v2 Migration — Phase 0 Confirmed API Mapping
 
-Status: **Phase 0 complete** (spike + API confirmation). Gates Phases 1–7.
+Status: **Migration complete.** Phase 0 (spike + API confirmation) is recorded
+below; Phases 1–7 are implemented on `feat/mcp-v2`. The full suite passes on
+`mcp==2.0.0`: **1099 non-integration + 39 integration = 1138 tests green**,
+`ruff format`/`check` clean. The Phase 0 mapping proved accurate — no surprises
+during implementation, and open item #1 (live upstream `session.initialize()`)
+is confirmed working by the stdio/SSE integration tests.
 
 This document records the *verified* v2 API surface, introspected against an
 actually-installed `mcp==2.0.0` (scratch venv, Python 3.12), not the migration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,9 @@ version = "0.1.0"
 description = "MCP Zero"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp>=1.26.0,<2.0.0",
-    "starlette>=0.36",
+    "mcp>=2.0.0,<3.0.0",
+    "httpx2>=2.10",
+    "starlette>=1.6",
     "uvicorn>=0.29",
     "PyJWT[crypto]>=2.8",
     "httpx>=0.27",

--- a/src/mcp_zero/proxy/proxy_server.py
+++ b/src/mcp_zero/proxy/proxy_server.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import mcp.types as types
 from mcp.server.lowlevel import Server
+from mcp.server.lowlevel.server import ServerRequestContext
 
 from mcp_zero.context import HookContext, PolicyDecision, RequestContext
 from mcp_zero.governance.config import PolicyEffect
@@ -47,24 +48,31 @@ class ProxyServer:
         self._policy_engine = policy_engine
         self._identity_required = identity_required
 
-        self._mcp_server = Server("mcp-zero-proxy")
-        self._register_handlers()
+        self._mcp_server = Server(
+            "mcp-zero-proxy",
+            on_list_tools=self._handle_list_tools,
+            on_call_tool=self._handle_call_tool,
+        )
 
     @property
     def mcp_server(self) -> Server:
         """Return the underlying MCP Server for wiring into a transport."""
         return self._mcp_server
 
-    def _register_handlers(self) -> None:
-        @self._mcp_server.list_tools()
-        async def handle_list_tools() -> list[types.Tool]:
-            return await self._list_tools()
+    async def _handle_list_tools(
+        self,
+        ctx: ServerRequestContext,
+        params: types.PaginatedRequestParams | None,
+    ) -> types.ListToolsResult:
+        return types.ListToolsResult(tools=await self._list_tools())
 
-        @self._mcp_server.call_tool()
-        async def handle_call_tool(
-            name: str, arguments: dict[str, Any] | None
-        ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
-            return await self._call_tool(name, arguments)
+    async def _handle_call_tool(
+        self,
+        ctx: ServerRequestContext,
+        params: types.CallToolRequestParams,
+    ) -> types.CallToolResult:
+        content = await self._call_tool(params.name, params.arguments)
+        return types.CallToolResult(content=content, is_error=False)
 
     async def _list_tools(self) -> list[types.Tool]:
         """Query all upstream servers and aggregate their tools with namespace prefixes.
@@ -249,7 +257,7 @@ class ProxyServer:
                 if self._pipeline:
                     response_payload = {
                         "content": [c.model_dump() for c in upstream_result.content],
-                        "isError": upstream_result.isError,
+                        "is_error": upstream_result.is_error,
                     }
                     post_ctx = hook_ctx.evolve(response_payload=response_payload)
                     post_result = await self._pipeline.execute(post_ctx)

--- a/src/mcp_zero/proxy/tool_router.py
+++ b/src/mcp_zero/proxy/tool_router.py
@@ -29,13 +29,8 @@ def parse_tool(namespaced_name: str) -> tuple[str, str]:
 
 def namespace_tools(server_name: str, tools: list[Tool]) -> list[Tool]:
     """Return copies of *tools* with their names prefixed by *server_name*."""
-    result: list[Tool] = []
-    for tool in tools:
-        result.append(
-            Tool(
-                name=namespace_tool(server_name, tool.name),
-                description=tool.description,
-                inputSchema=tool.inputSchema,
-            )
-        )
-    return result
+    # model_copy preserves all fields (input_schema, annotations, output_schema,
+    # etc.) while only rewriting the name.
+    return [
+        tool.model_copy(update={"name": namespace_tool(server_name, tool.name)}) for tool in tools
+    ]

--- a/src/mcp_zero/transport/http.py
+++ b/src/mcp_zero/transport/http.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from contextlib import AsyncExitStack
 
-import httpx
+import httpx2
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 
@@ -72,16 +72,18 @@ class StreamableHTTPTransport(MCPTransport):
                 if auth_token:
                     headers["Authorization"] = f"Bearer {auth_token}"
 
-                http_client: httpx.AsyncClient | None = None
+                http_client: httpx2.AsyncClient | None = None
                 if headers:
                     http_client = await stack.enter_async_context(
-                        httpx.AsyncClient(
+                        httpx2.AsyncClient(
                             headers=headers,
-                            timeout=httpx.Timeout(self._config.timeout_seconds),
+                            timeout=httpx2.Timeout(self._config.timeout_seconds),
                         )
                     )
 
-                read_stream, write_stream, _ = await stack.enter_async_context(
+                # mcp v2 yields a 2-tuple (read, write); the v1 session-id
+                # element was removed.
+                read_stream, write_stream = await stack.enter_async_context(
                     streamable_http_client(
                         self._config.url,  # type: ignore[arg-type]
                         http_client=http_client,

--- a/tests/fixtures/echo_server.py
+++ b/tests/fixtures/echo_server.py
@@ -16,19 +16,23 @@ import asyncio
 
 from mcp.server.lowlevel import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
 
 
-def _build_server() -> Server:
-    server = Server("echo-test-server")
-
-    @server.list_tools()
-    async def list_tools() -> list[Tool]:
-        return [
+async def _list_tools(ctx, params: PaginatedRequestParams | None) -> ListToolsResult:
+    return ListToolsResult(
+        tools=[
             Tool(
                 name="echo",
                 description="Returns the input text unchanged.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {"text": {"type": "string"}},
                     "required": ["text"],
@@ -37,7 +41,7 @@ def _build_server() -> Server:
             Tool(
                 name="greet",
                 description="Returns a greeting for the given name.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {"name": {"type": "string"}},
                     "required": ["name"],
@@ -46,7 +50,7 @@ def _build_server() -> Server:
             Tool(
                 name="get_secret_data",
                 description="Returns text containing PII for masking tests.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {},
                 },
@@ -54,42 +58,45 @@ def _build_server() -> Server:
             Tool(
                 name="reverse",
                 description="Returns the input text reversed.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {"text": {"type": "string"}},
                     "required": ["text"],
                 },
             ),
         ]
+    )
 
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict | None) -> list[TextContent]:
-        arguments = arguments or {}
 
-        if name == "echo":
-            text = arguments.get("text", "")
-            return [TextContent(type="text", text=text)]
+async def _call_tool(ctx, params: CallToolRequestParams) -> CallToolResult:
+    name = params.name
+    arguments = params.arguments or {}
 
-        if name == "greet":
-            person_name = arguments.get("name", "World")
-            return [TextContent(type="text", text=f"Hello, {person_name}!")]
+    if name == "echo":
+        text = arguments.get("text", "")
+        content = [TextContent(type="text", text=text)]
+    elif name == "greet":
+        person_name = arguments.get("name", "World")
+        content = [TextContent(type="text", text=f"Hello, {person_name}!")]
+    elif name == "get_secret_data":
+        # Deliberately returns text containing PII entities.
+        content = [
+            TextContent(
+                type="text",
+                text=("Contact John Smith at john.smith@example.com or call 555-123-4567."),
+            )
+        ]
+    elif name == "reverse":
+        text = arguments.get("text", "")
+        content = [TextContent(type="text", text=text[::-1])]
+    else:
+        content = [TextContent(type="text", text=f"Unknown tool: {name}")]
 
-        if name == "get_secret_data":
-            # Deliberately returns text containing PII entities.
-            return [
-                TextContent(
-                    type="text",
-                    text=("Contact John Smith at john.smith@example.com or call 555-123-4567."),
-                )
-            ]
+    return CallToolResult(content=content, is_error=False)
 
-        if name == "reverse":
-            text = arguments.get("text", "")
-            return [TextContent(type="text", text=text[::-1])]
 
-        return [TextContent(type="text", text=f"Unknown tool: {name}")]
-
-    return server
+def _build_server() -> Server:
+    return Server("echo-test-server", on_list_tools=_list_tools, on_call_tool=_call_tool)
 
 
 async def main() -> None:

--- a/tests/fixtures/echo_server_sse.py
+++ b/tests/fixtures/echo_server_sse.py
@@ -13,23 +13,27 @@ import sys
 import uvicorn
 from mcp.server.lowlevel import Server
 from mcp.server.sse import SseServerTransport
-from mcp.types import TextContent, Tool
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Mount, Route
 
 
-def _build_server() -> Server:
-    server = Server("echo-test-server")
-
-    @server.list_tools()
-    async def list_tools() -> list[Tool]:
-        return [
+async def _list_tools(ctx, params: PaginatedRequestParams | None) -> ListToolsResult:
+    return ListToolsResult(
+        tools=[
             Tool(
                 name="echo",
                 description="Returns the input text unchanged.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {"text": {"type": "string"}},
                     "required": ["text"],
@@ -38,7 +42,7 @@ def _build_server() -> Server:
             Tool(
                 name="greet",
                 description="Returns a greeting for the given name.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {"name": {"type": "string"}},
                     "required": ["name"],
@@ -47,7 +51,7 @@ def _build_server() -> Server:
             Tool(
                 name="get_secret_data",
                 description="Returns text containing PII for masking tests.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {},
                 },
@@ -55,41 +59,44 @@ def _build_server() -> Server:
             Tool(
                 name="reverse",
                 description="Returns the input text reversed.",
-                inputSchema={
+                input_schema={
                     "type": "object",
                     "properties": {"text": {"type": "string"}},
                     "required": ["text"],
                 },
             ),
         ]
+    )
 
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict | None) -> list[TextContent]:
-        arguments = arguments or {}
 
-        if name == "echo":
-            text = arguments.get("text", "")
-            return [TextContent(type="text", text=text)]
+async def _call_tool(ctx, params: CallToolRequestParams) -> CallToolResult:
+    name = params.name
+    arguments = params.arguments or {}
 
-        if name == "greet":
-            person_name = arguments.get("name", "World")
-            return [TextContent(type="text", text=f"Hello, {person_name}!")]
+    if name == "echo":
+        text = arguments.get("text", "")
+        content = [TextContent(type="text", text=text)]
+    elif name == "greet":
+        person_name = arguments.get("name", "World")
+        content = [TextContent(type="text", text=f"Hello, {person_name}!")]
+    elif name == "get_secret_data":
+        content = [
+            TextContent(
+                type="text",
+                text="Contact John Smith at john.smith@example.com or call 555-123-4567.",
+            )
+        ]
+    elif name == "reverse":
+        text = arguments.get("text", "")
+        content = [TextContent(type="text", text=text[::-1])]
+    else:
+        content = [TextContent(type="text", text=f"Unknown tool: {name}")]
 
-        if name == "get_secret_data":
-            return [
-                TextContent(
-                    type="text",
-                    text="Contact John Smith at john.smith@example.com or call 555-123-4567.",
-                )
-            ]
+    return CallToolResult(content=content, is_error=False)
 
-        if name == "reverse":
-            text = arguments.get("text", "")
-            return [TextContent(type="text", text=text[::-1])]
 
-        return [TextContent(type="text", text=f"Unknown tool: {name}")]
-
-    return server
+def _build_server() -> Server:
+    return Server("echo-test-server", on_list_tools=_list_tools, on_call_tool=_call_tool)
 
 
 def create_sse_app() -> Starlette:

--- a/tests/integration/test_stdio_integration.py
+++ b/tests/integration/test_stdio_integration.py
@@ -237,7 +237,7 @@ class TestStdioToolListing:
             tools = await proxy._list_tools()
 
         by_name = {t.name: t for t in tools}
-        echo_schema = by_name["test-stdio__echo"].inputSchema
+        echo_schema = by_name["test-stdio__echo"].input_schema
         assert echo_schema["type"] == "object"
         assert "text" in echo_schema["properties"]
 

--- a/tests/masking/test_output_masking.py
+++ b/tests/masking/test_output_masking.py
@@ -52,7 +52,7 @@ class TestOutputMaskingBasic:
         ctx = _make_ctx(
             response_payload={
                 "content": [{"type": "text", "text": "User John Doe has 3 issues"}],
-                "isError": False,
+                "is_error": False,
             }
         )
         result = await hook.on_post_masking(ctx)
@@ -89,7 +89,7 @@ class TestOutputMaskingBasic:
                     {"type": "text", "text": "john@example.com"},
                     {"type": "text", "text": "Jane Smith"},
                 ],
-                "isError": False,
+                "is_error": False,
             }
         )
         result = await hook.on_post_masking(ctx)
@@ -109,7 +109,7 @@ class TestOutputMaskingBasic:
         ctx = _make_ctx(
             response_payload={
                 "content": [{"type": "text", "text": "safe text"}],
-                "isError": False,
+                "is_error": False,
             }
         )
         result = await hook.on_post_masking(ctx)
@@ -493,7 +493,7 @@ class TestOutputMaskingErrorMessages:
                         "text": "Error: user john@example.com not found",
                     }
                 ],
-                "isError": True,
+                "is_error": True,
             }
         )
         result = await hook.on_post_masking(ctx)
@@ -502,5 +502,5 @@ class TestOutputMaskingErrorMessages:
         assert (
             result.response_payload["content"][0]["text"] == "Error: user <EMAIL_ADDRESS> not found"
         )
-        # isError flag is preserved (non-string, passes through)
-        assert result.response_payload["isError"] is True
+        # is_error flag is preserved (non-string, passes through)
+        assert result.response_payload["is_error"] is True

--- a/tests/proxy/test_proxy_server.py
+++ b/tests/proxy/test_proxy_server.py
@@ -48,13 +48,13 @@ def make_configs():
 
 
 def make_tool(name="get_weather", description="Get weather"):
-    return Tool(name=name, description=description, inputSchema={"type": "object"})
+    return Tool(name=name, description=description, input_schema={"type": "object"})
 
 
 def make_call_result(text="result"):
     return CallToolResult(
         content=[TextContent(type="text", text=text)],
-        isError=False,
+        is_error=False,
     )
 
 
@@ -440,7 +440,7 @@ class TestProxyServerWithPipeline:
             # Post-pipeline masks the response
             masked_payload = {
                 "content": [{"type": "text", "text": "Hello <PERSON> at <EMAIL_ADDRESS>"}],
-                "isError": False,
+                "is_error": False,
             }
             return PipelineResult(
                 context=ctx.evolve(

--- a/tests/proxy/test_tool_router.py
+++ b/tests/proxy/test_tool_router.py
@@ -48,8 +48,8 @@ class TestParseTool:
 class TestNamespaceTools:
     def test_prefixes_all_tools(self):
         tools = [
-            Tool(name="get_weather", description="Get weather", inputSchema={"type": "object"}),
-            Tool(name="get_time", description="Get time", inputSchema={"type": "object"}),
+            Tool(name="get_weather", description="Get weather", input_schema={"type": "object"}),
+            Tool(name="get_time", description="Get time", input_schema={"type": "object"}),
         ]
         result = namespace_tools("weather-srv", tools)
         assert len(result) == 2
@@ -58,10 +58,10 @@ class TestNamespaceTools:
 
     def test_preserves_description_and_schema(self):
         schema = {"type": "object", "properties": {"city": {"type": "string"}}}
-        tools = [Tool(name="get", description="desc", inputSchema=schema)]
+        tools = [Tool(name="get", description="desc", input_schema=schema)]
         result = namespace_tools("srv", tools)
         assert result[0].description == "desc"
-        assert result[0].inputSchema == schema
+        assert result[0].input_schema == schema
 
     def test_empty_list(self):
         assert namespace_tools("srv", []) == []

--- a/tests/transport/test_http.py
+++ b/tests/transport/test_http.py
@@ -23,11 +23,10 @@ def mock_sdk(monkeypatch):
 
     read_stream = MagicMock()
     write_stream = MagicMock()
-    get_session_id = MagicMock(return_value=None)
 
-    # streamable_http_client yields (read, write, get_session_id)
+    # mcp v2 streamable_http_client yields (read, write)
     mock_http_cm = AsyncMock()
-    mock_http_cm.__aenter__ = AsyncMock(return_value=(read_stream, write_stream, get_session_id))
+    mock_http_cm.__aenter__ = AsyncMock(return_value=(read_stream, write_stream))
     mock_http_cm.__aexit__ = AsyncMock(return_value=False)
 
     # ClientSession context manager
@@ -123,7 +122,7 @@ class TestStreamableHTTPTransport:
         ctx = RequestContext(correlation_id="c-1", trace_id="t-1")
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
@@ -145,7 +144,7 @@ class TestStreamableHTTPTransport:
         ctx = RequestContext(correlation_id="c-1")  # trace_id defaults to None
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
@@ -172,7 +171,7 @@ class TestStreamableHTTPTransport:
         cfg = make_http_config()
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
@@ -189,7 +188,7 @@ class TestStreamableHTTPTransport:
         ctx = RequestContext(correlation_id="c-1", trace_id="t-1")
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
@@ -212,7 +211,7 @@ class TestStreamableHTTPTransport:
         ctx = RequestContext()
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
@@ -245,7 +244,7 @@ class TestStreamableHTTPTransport:
         )
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
@@ -269,7 +268,7 @@ class TestStreamableHTTPTransport:
         ctx = RequestContext(correlation_id="c-1", trace_id="t-1")
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)
@@ -292,7 +291,7 @@ class TestStreamableHTTPTransport:
         )
         t = StreamableHTTPTransport(cfg)
 
-        with patch("mcp_zero.transport.http.httpx.AsyncClient") as mock_httpx:
+        with patch("mcp_zero.transport.http.httpx2.AsyncClient") as mock_httpx:
             mock_httpx_inst = AsyncMock()
             mock_httpx_inst.__aenter__ = AsyncMock(return_value=mock_httpx_inst)
             mock_httpx_inst.__aexit__ = AsyncMock(return_value=False)


### PR DESCRIPTION
## Summary

Migrates the gateway from the `mcp` Python SDK **v1 → v2** (`mcp==2.0.0`). This supersedes Dependabot PR #199, which only widened the version range to admit v2 and broke CI (the code was built against the v1 low-level `Server` API).

A Phase 0 spike introspected an actually-installed `mcp==2.0.0` (not the migration guide, several of whose claims proved wrong) and produced a confirmed API mapping — see `docs/mcp-v2-migration.md`. The migration turned out smaller and lower-risk than first feared: the client transports, the ASGI session manager, and the SSE transport all survived v2 largely intact.

## Changes

- **Server** — `proxy_server.py` decorator handlers (`@server.list_tools()` / `@server.call_tool()`) → constructor `on_list_tools`/`on_call_tool` callbacks taking `(ServerRequestContext, params)` and returning full `ListToolsResult`/`CallToolResult` objects.
- **Types** — snake_case field renames (`inputSchema`→`input_schema`, `isError`→`is_error`) across proxy, fixtures, and tests; the internal masking payload standardized on snake_case. `mcp.types` remains a permanent alias for `mcp_types`, so imports are unchanged.
- **tool_router** — namespaces tools via `model_copy` to preserve all v2 `Tool` fields (`output_schema`, `annotations`, …) instead of dropping them.
- **HTTP transport** — `streamable_http_client` now yields a **2-tuple** (the v1 session-id element was removed) and its `http_client` uses **httpx2**. `stdio`/`sse` transports needed no change.
- **ASGI wiring** (`proxy/app.py`) — **no changes required**; `SseServerTransport` and `StreamableHTTPSessionManager` are unchanged in v2. SSE is not removed, so `MCP_SSE_ENABLED` and the SSE tests are kept.
- **Deps** — `mcp>=2.0.0,<3.0.0`, add `httpx2>=2.10`, keep `httpx>=0.27` (gateway JWKS/OBO code), `starlette>=1.6`.

## Testing

Full suite green on `mcp==2.0.0` (Python 3.12, local):

- **1099** non-integration + **39** integration tests pass (1138 total)
- `ruff format` / `ruff check` clean

The integration tests spawn live subprocess MCP servers over stdio and SSE, confirming the Phase 0 open item that upstream `session.initialize()` still works against real 2025-era servers.

## Notes / follow-ups

- Validated locally on Python 3.12; CI also runs 3.14 — watch presidio/spacy + pydantic 2.13 resolution there.
- Closes out Dependabot PR #199 (will comment there pointing here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
